### PR TITLE
Making tpg disabling work as expected

### DIFF
--- a/src/runconf_ui/config_files/detector_configs/np02_configuration.yml
+++ b/src/runconf_ui/config_files/detector_configs/np02_configuration.yml
@@ -45,7 +45,7 @@ PanelOptions:
 
     Systems:
       - TPG:
-          subsystem_dependent: False
+          subsystem_dependent: True
           display_full_system: False
 
           components:

--- a/src/runconf_ui/widgets/enable_disable_base.py
+++ b/src/runconf_ui/widgets/enable_disable_base.py
@@ -156,7 +156,8 @@ class EnableDisablePanel(Static):
                 button_widget.add_class("detector_subsystem_button_partial")
                 button_widget.label = f"{button} (Partially Enabled)"
             elif button_state == SubsystemStatus.TOP_LEVEL_DISABLED:
-                button_widget.disabled = True
+                if (self.id != "TPG_subsystem_panel"):
+                    button_widget.disabled = True
                 button_widget.add_class("detector_subsystem_button_disabled")
                 button_widget.label = f"{button} (Disabled)"
             elif SubsystemStatus.STATE_NOT_DEFINED:


### PR DESCRIPTION
Temporary fix for TPG panel to make it possible to re-enable TPG after both subsystems were disabled. 