### PR TITLE
feat: Improve crashes, check apparatus defaults

### DIFF
--- a/src/runconf_ui/apps/runconf_ui_main.py
+++ b/src/runconf_ui/apps/runconf_ui_main.py
@@ -198,7 +198,7 @@ def cli(
     
     """
     if apparatus is None:
-        raise ValueError(
+        raise click.UsageError(
             "Apparatus must be specified with -a or APPARATUS env variable"
         )
 

--- a/src/runconf_ui/apps/runconf_ui_main.py
+++ b/src/runconf_ui/apps/runconf_ui_main.py
@@ -183,6 +183,19 @@ def cli(
     """
     Launches the interactive configuration UI and saves selected configurations
     to the specified output directory. Invoked with the runconf-shifter-ui command.
+    
+    \f
+    
+    :param apparatus: DAQ apparatus name (e.g., NP02, NP04)
+    :param config_directory: Path to configuration directory
+    :param output_directory: Directory to save run configs to
+    :param use_local: Use local filesystem instead of remote API
+    :param config_file_name: Config file to find in the ops repo
+    :param base_url: URL for the BASE repository
+    :param ops_url: URL for the operations repository
+    :param log_level: Log level (INFO, WARNING, DEBUG)
+
+    
     """
     if apparatus is None:
         raise ValueError(

--- a/src/runconf_ui/apps/runconf_ui_main.py
+++ b/src/runconf_ui/apps/runconf_ui_main.py
@@ -49,8 +49,9 @@ def get_apparatus_defaults(apparatus: str) -> ApparatusDefaults:
     with open(script_path) as f:
         for line in f:
             match = export_pattern.match(line.strip())
-            if match:
-                key, value = match.groups()
+            if match:                
+                key = match.group(1)
+                value = next((v for v in match.groups()[1:] if v is not None), "")
                 defaults[key] = value
 
     # Map the environment variable names to your internal TypedDict structure

--- a/src/runconf_ui/apps/runconf_ui_main.py
+++ b/src/runconf_ui/apps/runconf_ui_main.py
@@ -41,7 +41,10 @@ def get_apparatus_defaults(apparatus: str) -> ApparatusDefaults:
 
     # Matches lines like: export KEY="VALUE" or export KEY=${OTHER_VAR}/value
     # Specifically captures the key and everything inside the quotes
-    export_pattern = re.compile(r'^\s*export\s+([A-Za-z0-9_]+)\s*=\s*"([^"]+)"')
+    export_pattern = re.compile(
+        r'^\s*export\s+([A-Za-z0-9_]+)\s*=\s*(?:"([^"]*)"'
+        r"|'([^']*)'|([^#\s]*))"
+    )
 
     with open(script_path) as f:
         for line in f:

--- a/src/runconf_ui/apps/runconf_ui_main.py
+++ b/src/runconf_ui/apps/runconf_ui_main.py
@@ -32,7 +32,7 @@ def get_apparatus_defaults(apparatus: str) -> ApparatusDefaults:
     script_path = shutil.which(script_name)
 
     if not script_path:
-        raise ValueError(
+        raise click.UsageError(
             f"Could not find setup script '{script_name}'. "
             f"Please add '{script_name}' to runconf-ui/scripts and to the pyproject.toml"
         )
@@ -195,9 +195,8 @@ def cli(
             ops_url = apparatus_defaults.get("ops_url")
             config_file_name = apparatus_defaults.get("config_file_name")
         elif any(v is None for v in apparatus_vars):
-            raise ValueError(
-                "If any of base_url, ops_url, or config_file_name are not specified, all three must be resolved from the apparatus defaults."
-            )
+            raise click.UsageError(
+                "Specify all of --base-url, --ops-url, and --config-file-name together, or omit all three to use apparatus defaults."            )
 
     ctx = RunconfContext(
         apparatus=apparatus,

--- a/src/runconf_ui/apps/runconf_ui_main.py
+++ b/src/runconf_ui/apps/runconf_ui_main.py
@@ -3,6 +3,8 @@ Main app for runconf-ui
 """
 
 import os
+import re
+import shutil
 from pathlib import Path
 from typing import TypedDict
 
@@ -16,38 +18,61 @@ class ApparatusDefaults(TypedDict):
     base_url: str
     ops_url: str
     config_file_name: str
+    config_dir: str
 
 
-APPARATUS_DEFAULTS: dict[str, ApparatusDefaults] = {
-    "NP02": {
-        "base_url": "ssh://git@gitlab.cern.ch:7999/dune-daq/online/ehn1-daqconfigs.git",
-        "ops_url": "https://gitlab.cern.ch/dune-daq/online/np02-configs-operation.git",
-        "config_file_name": "np02-session.data.xml",
-    },
-    "NP04": {
-        "base_url": "ssh://git@gitlab.cern.ch:7999/dune-daq/online/ehn1-daqconfigs.git",
-        "ops_url": "https://gitlab.cern.ch/dune-daq/online/np04-configs-operation.git",
-        "config_file_name": "np04-session.data.xml",
-    },
-}
+def get_apparatus_defaults(apparatus: str) -> ApparatusDefaults:
+    """Dynamically finds and parses the installed environment setup shell script
+    for a given apparatus to extract configuration defaults.
+    """
+    app_lower = apparatus.lower()
+    script_name = f"runconf_{app_lower}_env_setup.sh"
 
+    # Locate where the script was installed in the current environment's PATH
+    script_path = shutil.which(script_name)
 
-def get_apparatus_default(apparatus: str) -> ApparatusDefaults:
-    """Resolve a default value for a given apparatus and property key."""
-    apparatus = apparatus.upper()
-
-    if apparatus not in APPARATUS_DEFAULTS:
+    if not script_path:
         raise ValueError(
-            f"Apparatus '{apparatus}' not recognized. Valid options are: {', '.join(APPARATUS_DEFAULTS.keys())}"
+            f"Could not find setup script '{script_name}'. "
+            f"Please add '{script_name}' to runconf-ui/scripts and to the pyproject.toml"
         )
 
-    apparatus_defaults = APPARATUS_DEFAULTS.get(apparatus)
-    if apparatus_defaults is None:
-        raise ValueError(
-            f"No defaults found for apparatus '{apparatus}'. Please specify all config options with command line options or environment variables."
+    defaults: dict[str, str] = {}
+
+    # Matches lines like: export KEY="VALUE" or export KEY=${OTHER_VAR}/value
+    # Specifically captures the key and everything inside the quotes
+    export_pattern = re.compile(r'^\s*export\s+([A-Za-z0-9_]+)\s*=\s*"([^"]+)"')
+
+    with open(script_path) as f:
+        for line in f:
+            match = export_pattern.match(line.strip())
+            if match:
+                key, value = match.groups()
+                defaults[key] = value
+
+    # Map the environment variable names to your internal TypedDict structure
+    # Providing fallbacks in case the script structure shifts slightly
+    mapped_defaults: ApparatusDefaults = {
+        "base_url": defaults.get("BASE_URL", ""),
+        "ops_url": defaults.get("OPERATION_URL", ""),
+        "config_file_name": defaults.get("SESSION_FILE", ""),
+        "config_dir": defaults.get("CONFIG_DIR", ""),
+    }
+
+    # Evaluate simple string interpolations if necessary (like ${DBT_AREA_ROOT})
+    if "${DBT_AREA_ROOT}" in mapped_defaults["config_dir"]:
+        dbt_root = os.getenv("DBT_AREA_ROOT", "")
+        mapped_defaults["config_dir"] = mapped_defaults["config_dir"].replace(
+            "${DBT_AREA_ROOT}", dbt_root
         )
 
-    return apparatus_defaults
+    # Sanity check to make sure we actually extracted meaningful data
+    if not any(mapped_defaults.values()):
+        raise ValueError(
+            f"Script '{script_name}' was found but yielded no default variables."
+        )
+
+    return mapped_defaults
 
 
 def get_exit_msg(backend: RunconfUIBackend) -> str:
@@ -165,7 +190,7 @@ def cli(
     if not use_local:
         apparatus_vars = (base_url, ops_url, config_file_name)
         if all(v is None for v in apparatus_vars):
-            apparatus_defaults = get_apparatus_default(apparatus)
+            apparatus_defaults = get_apparatus_defaults(apparatus)
             base_url = apparatus_defaults.get("base_url")
             ops_url = apparatus_defaults.get("ops_url")
             config_file_name = apparatus_defaults.get("config_file_name")

--- a/src/runconf_ui/apps/runconf_ui_main.py
+++ b/src/runconf_ui/apps/runconf_ui_main.py
@@ -4,11 +4,50 @@ Main app for runconf-ui
 
 import os
 from pathlib import Path
+from typing import TypedDict
 
 import click
 
 from runconf_ui import RunconfContext, RunconfUIApp, RunconfUIBackend
 from runconf_ui.utils import LogLevels
+
+
+class ApparatusDefaults(TypedDict):
+    base_url: str
+    ops_url: str
+    config_file_name: str
+
+
+APPARATUS_DEFAULTS: dict[str, ApparatusDefaults] = {
+    "NP02": {
+        "base_url": "ssh://git@gitlab.cern.ch:7999/dune-daq/online/ehn1-daqconfigs.git",
+        "ops_url": "https://gitlab.cern.ch/dune-daq/online/np02-configs-operation.git",
+        "config_file_name": "np02-session.data.xml",
+    },
+    "NP04": {
+        "base_url": "ssh://git@gitlab.cern.ch:7999/dune-daq/online/ehn1-daqconfigs.git",
+        "ops_url": "https://gitlab.cern.ch/dune-daq/online/np04-configs-operation.git",
+        "config_file_name": "np04-session.data.xml",
+    },
+}
+
+
+def get_apparatus_default(apparatus: str) -> ApparatusDefaults:
+    """Resolve a default value for a given apparatus and property key."""
+    apparatus = apparatus.upper()
+
+    if apparatus not in APPARATUS_DEFAULTS:
+        raise ValueError(
+            f"Apparatus '{apparatus}' not recognized. Valid options are: {', '.join(APPARATUS_DEFAULTS.keys())}"
+        )
+
+    apparatus_defaults = APPARATUS_DEFAULTS.get(apparatus)
+    if apparatus_defaults is None:
+        raise ValueError(
+            f"No defaults found for apparatus '{apparatus}'. Please specify all config options with command line options or environment variables."
+        )
+
+    return apparatus_defaults
 
 
 def get_exit_msg(backend: RunconfUIBackend) -> str:
@@ -54,6 +93,7 @@ def get_exit_msg(backend: RunconfUIBackend) -> str:
     type=click.Path(),
     help="Path to your local config directory. This should contain your configs. Can be read from the CONFIG_DIR environment variable.",
     envvar="CONFIG_DIR",
+    default=Path("base-configs"),
 )
 @click.option(
     "-a",
@@ -86,7 +126,6 @@ def get_exit_msg(backend: RunconfUIBackend) -> str:
 @click.option(
     "-b",
     "--base-url",
-    default="ssh://git@gitlab.cern.ch:7999/dune-daq/online/ehn1-daqconfigs.git",
     help="URL for the BASE repository. Can be read from the BASE_URL environment variable.",
     envvar="BASE_URL",
 )
@@ -113,20 +152,28 @@ def cli(
     ops_url: str,
     log_level: LogLevels = "INFO",
 ):
-    """CLI interface for runconf-ui.
-
+    """
     Launches the interactive configuration UI and saves selected configurations
     to the specified output directory. Invoked with the runconf-shifter-ui command.
-
-    :param apparatus: DAQ apparatus name (e.g., NP02, NP04)
-    :param config_directory: Path to configuration directory
-    :param output_directory: Directory to save run configs to
-    :param use_local: Use local filesystem instead of remote API
-    :param config_file_name: Config file to find in the ops repo
-    :param base_url: URL for the BASE repository
-    :param ops_url: URL for the operations repository
-    :param log_level: Log level (INFO, WARNING, DEBUG)
     """
+    if apparatus is None:
+        raise ValueError(
+            "Apparatus must be specified with -a or APPARATUS env variable"
+        )
+
+    # When we JUST provide the apparatus
+    if not use_local:
+        apparatus_vars = (base_url, ops_url, config_file_name)
+        if all(v is None for v in apparatus_vars):
+            apparatus_defaults = get_apparatus_default(apparatus)
+            base_url = apparatus_defaults.get("base_url")
+            ops_url = apparatus_defaults.get("ops_url")
+            config_file_name = apparatus_defaults.get("config_file_name")
+        elif any(v is None for v in apparatus_vars):
+            raise ValueError(
+                "If any of base_url, ops_url, or config_file_name are not specified, all three must be resolved from the apparatus defaults."
+            )
+
     ctx = RunconfContext(
         apparatus=apparatus,
         conf_directory=Path(config_directory),


### PR DESCRIPTION
# Description
* Checks for apparatus defaults currently NP02 and NP04 
* Does by parsing the standard setup scripts
* Lets the user start with `runconf-shifter-ui -a [apparatus]
* Cleaner start up crashes

Testing: Start runconf-shifter-ui with either `-a np02` or `-a np04`. Also test start-up after running `runconf_np02_env_setup.sh`. Additionally test breaking path with either no `-a` (and no setup script) and `-a foo` to check for breaking paths (no apparatus or non-existent apparatus)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [x] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
