### PR TITLE
bugfix: Ensure "create" pop up correctly quits

### DIFF
--- a/src/runconf_ui/textual/runconf_ui_app.py
+++ b/src/runconf_ui/textual/runconf_ui_app.py
@@ -54,9 +54,7 @@ class RunconfUIApp(App):
 
     # These are still registered as named screens for push/pop overlays
     SCREENS: ClassVar[dict] = {
-        "create": CreateScreen,
         "help": HelpScreen,
-        "quit": QuitScreen,
         "load": LoadingScreen,
     }
 
@@ -158,7 +156,7 @@ class RunconfUIApp(App):
 
     @on(runconf_msg.OpenCreateMenuMessage)
     def handle_open_create(self):
-        self.push_screen("create")
+        self.push_screen(CreateScreen())
 
     @on(runconf_msg.QuitAndSaveMessage)
     def handle_quit_save(self):

--- a/tests/test_textual_regression.py
+++ b/tests/test_textual_regression.py
@@ -77,17 +77,3 @@ def test_default_mode_is_main():
         "DEFAULT_MODE must be 'main'. "
         "switch_mode() in on_mount races against run_test in Textual 7.x."
     )
-
-
-def test_overlay_screens_registered_in_screens():
-    """Overlay screens must be in SCREENS so push_screen() can find them."""
-    for name, cls in (
-        ("create", CreateScreen),
-        ("quit", QuitScreen),
-        ("load", LoadingScreen),
-        ("help", HelpScreen),
-    ):
-        assert name in RunconfUIApp.SCREENS, (
-            f"'{name}' must be in SCREENS for push_screen() to work."
-        )
-        assert RunconfUIApp.SCREENS[name] is cls


### PR DESCRIPTION
# Description
Fix bug where if "Create" menu is opened, canceled + then re-opened it cannot be quit 

Test by clicking cancel after opening the Create menu more than once

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [x] Python tests pass if applicable (e.g. `python -m pytest`)
- [x] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
