### PR TITLE
bugfix: Adjustable option reset now resets to the initial value of a parameter + displays that value

### DIFF
--- a/src/runconf_ui/textual/widgets/adjustable_attribute_panel.py
+++ b/src/runconf_ui/textual/widgets/adjustable_attribute_panel.py
@@ -27,7 +27,7 @@ class AdjustableAttributeContainer(Static):
         super().__init__(*args, **kwargs)
         self._adjust_node = node
         self._group_id = group_id
-        self._curr_value = self._adjust_node.node.get()
+        self._curr_value = self._init_value = self._adjust_node.node.get()
 
     def compose(self):
         """Compose the attribute container with label, input, and buttons.
@@ -107,7 +107,8 @@ class AdjustableAttributeContainer(Static):
         :returns: A formatted string representing the current value
         """
         return (
-            f"([dim purple]Current Value: [/][bold red]{self._curr_value}[/bold red])"
+            f"[dim purple]Current Value: [/][bold red]{self._curr_value}[/bold red]\n"
+            f"[dim grey]Init value: [dim red]{self._init_value}[/]"
         )
 
     @on(Button.Pressed, "#reset")
@@ -116,8 +117,8 @@ class AdjustableAttributeContainer(Static):
 
         :param _: The Button.Pressed event (unused)
         """
-        self.query_one(Input).value = str(self._curr_value)
-        self._handle_value_changed(self._curr_value)
+        self.query_one(Input).value = str(self._init_value)
+        self._handle_value_changed(self._init_value)
 
     @on(Button.Pressed, "#apply")
     def handle_apply(self, _):

--- a/src/runconf_ui/textual/widgets/adjustable_attribute_panel.py
+++ b/src/runconf_ui/textual/widgets/adjustable_attribute_panel.py
@@ -108,7 +108,7 @@ class AdjustableAttributeContainer(Static):
         """
         return (
             f"[dim purple]Current Value: [/][bold red]{self._curr_value}[/bold red]\n"
-            f"[dim grey]Init value: [dim red]{self._init_value}[/]"
+            f"[dim grey]Init value: [/][dim red]{self._init_value}[/]"
         )
 
     @on(Button.Pressed, "#reset")


### PR DESCRIPTION
# Description
Adjustable option reset now resets to the initial value of a parameter + displays that value

Test by changing adjustable attribute + pressing reset

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [x] Python tests pass if applicable (e.g. `python -m pytest`)
- [x] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [x] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
