### PR TITLE
bugfix: Fix config save directory to use SESSION_NAME when generating local directory

### DIFF
--- a/scripts/runconf_np02_env_setup.sh
+++ b/scripts/runconf_np02_env_setup.sh
@@ -3,6 +3,7 @@
 export APPARATUS="np02"
 
 export SESSION_FILE="np02-session.data.xml"
+export SESSION_NAME="np02-test"
 export CONFIG_DIR="${DBT_AREA_ROOT}/np02-runs"
 export OPERATION_URL="https://gitlab.cern.ch/dune-daq/online/np02-configs-operation.git"
 export BASE_URL="ssh://git@gitlab.cern.ch:7999/dune-daq/online/ehn1-daqconfigs.git"

--- a/scripts/runconf_np04_env_setup.sh
+++ b/scripts/runconf_np04_env_setup.sh
@@ -3,6 +3,7 @@
 export APPARATUS="np02"
 
 export SESSION_FILE="np02-session.data.xml"
+export SESSION_NAME="np02-test"
 export CONFIG_DIR="${DBT_AREA_ROOT}/np02-runs"
 export OPERATION_URL="https://gitlab.cern.ch/dune-daq/online/np02-configs-operation.git"
 export BASE_URL="https://gitlab.cern.ch/dune-daq/online/ehn1-daqconfigs"

--- a/src/runconf_ui/apps/runconf_ui_main.py
+++ b/src/runconf_ui/apps/runconf_ui_main.py
@@ -46,7 +46,10 @@ def get_exit_msg(backend: RunconfUIBackend) -> str:
 
     return os.getenv("EHN1_RC_LAUNCH", run_cmd)
 
-
+# HW Again a bit hacky, but cleaner than defining in the CLI itself!
+DEFAULT_CONFIG_EXTENSION = f"-{os.getenv('SESSION_NAME')}" if os.getenv("SESSION_NAME") else ""
+DEFAULT_CONFIG_PATH = Path().cwd()/f"config{DEFAULT_CONFIG_EXTENSION}"
+    
 @click.command()
 @click.option(
     "-c",
@@ -54,6 +57,7 @@ def get_exit_msg(backend: RunconfUIBackend) -> str:
     type=click.Path(),
     help="Path to your local config directory. This should contain your configs. Can be read from the CONFIG_DIR environment variable.",
     envvar="CONFIG_DIR",
+    default=DEFAULT_CONFIG_PATH
 )
 @click.option(
     "-a",
@@ -141,19 +145,3 @@ def cli(
     backend = RunconfUIBackend(ctx)
     RunconfUIApp(backend).run()
     print(get_exit_msg(backend))
-
-
-if __name__ == "__main__":
-    # FOR TESTING ONLY
-    ctx_ = RunconfContext(
-        apparatus="dummy",
-        conf_directory=Path("/tmp/pytest-of-hwallace/pytest-current/configscurrent"),
-        use_local=True,
-        output_directory=Path("test-cfg"),
-        log_level="INFO",
-    )
-    backend_ = RunconfUIBackend(ctx_)
-
-    RunconfUIApp(backend_).run()
-
-    print(get_exit_msg(backend_))


### PR DESCRIPTION
# Description
* Configs were all downloaded to "configs" rather than "config-${TMUX_SESSION_NAME}"

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [x] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
