### PR TITLE
bugfix: Use full absolute path for configs

### DIFF
--- a/src/runconf_ui/apps/runconf_ui_main.py
+++ b/src/runconf_ui/apps/runconf_ui_main.py
@@ -49,7 +49,7 @@ def get_apparatus_defaults(apparatus: str) -> ApparatusDefaults:
     with open(script_path) as f:
         for line in f:
             match = export_pattern.match(line.strip())
-            if match:                
+            if match:
                 key = match.group(1)
                 value = next((v for v in match.groups()[1:] if v is not None), "")
                 defaults[key] = value
@@ -95,7 +95,7 @@ def get_exit_msg(backend: RunconfUIBackend) -> str:
     if backend.config_session is None:
         return "No session selected, cannot use DRUNC"
 
-    config_file = backend.config_save_path
+    config_file = backend.final_save_path.resolve()
 
     if not config_file.is_file():
         return f"Config file {config_file} not created, cannot use DRUNC"
@@ -184,9 +184,9 @@ def cli(
     """
     Launches the interactive configuration UI and saves selected configurations
     to the specified output directory. Invoked with the runconf-shifter-ui command.
-    
+
     \f
-    
+
     :param apparatus: DAQ apparatus name (e.g., NP02, NP04)
     :param config_directory: Path to configuration directory
     :param output_directory: Directory to save run configs to
@@ -196,7 +196,7 @@ def cli(
     :param ops_url: URL for the operations repository
     :param log_level: Log level (INFO, WARNING, DEBUG)
 
-    
+
     """
     if apparatus is None:
         raise click.UsageError(
@@ -213,7 +213,8 @@ def cli(
             config_file_name = apparatus_defaults.get("config_file_name")
         elif any(v is None for v in apparatus_vars):
             raise click.UsageError(
-                "Specify all of --base-url, --ops-url, and --config-file-name together, or omit all three to use apparatus defaults."            )
+                "Specify all of --base-url, --ops-url, and --config-file-name together, or omit all three to use apparatus defaults."
+            )
 
     ctx = RunconfContext(
         apparatus=apparatus,

--- a/src/runconf_ui/backend/runconf_ui_backend.py
+++ b/src/runconf_ui/backend/runconf_ui_backend.py
@@ -302,6 +302,15 @@ class RunconfUIBackend:
         """
         return self.current_save_dir / self._save_path.name
 
+    @property
+    def final_save_path(self) -> Path:
+        """Get the path where the config will be saved.
+
+        :returns: Path object representing the config save location
+        :rtype: Path
+        """
+        return self.final_save_dir / self._save_path.name
+
     def save_config(self) -> None:
         """
         Commit the in-memory config then write a consolidated copy to the


### PR DESCRIPTION
# Description
- Use full paths for configurations
- Link to current_config directory not timestamped archive

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [x] Python tests pass if applicable (e.g. `python -m pytest`)
- [x] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
