### PR TITLE
Feat: Partially enabled sate

### DIFF
--- a/src/runconf_ui/backend/runconf_ui_backend.py
+++ b/src/runconf_ui/backend/runconf_ui_backend.py
@@ -204,7 +204,7 @@ class RunconfUIBackend:
 
         self._logger = get_logger()
 
-        self._session_manager = _SessionManager(context)
+        self.session_manager = _SessionManager(context)
         self.apparatus = context.apparatus
 
         self._assembled: AssembledConfig | None = None
@@ -219,42 +219,6 @@ class RunconfUIBackend:
         self._logger.debug("Backend instantiated")
 
     # ------------------------------------------------------------------ #
-    # Session / version forwarding [I hate this]                         #
-    # ------------------------------------------------------------------ #
-
-    def get_daq_versions(self):
-        """Forward the request for available DAQ versions to the session manager."""
-        return self._session_manager.get_daq_versions()
-
-    def get_default_version(self):
-        """Forward the request for default DAQ version to the session manager."""
-        return self._session_manager.get_default_version()
-
-    def get_current_version(self):
-        """Forward the request for the current DAQ version to the session manager."""
-        return self._session_manager.get_current_version()
-
-    def get_sessions(self):
-        """Forward the request for available sessions to the session manager."""
-        return self._session_manager.get_sessions()
-
-    def get_current_session(self):
-        """Forward the request for the current session to the session manager."""
-        return self._session_manager.get_current_session()
-
-    def set_daq_version(self, version) -> None:
-        """Forward the request to set the DAQ version to the session manager.
-        :param version: the DAQ version to set, e.g. "v3.0.0"
-        """
-        self._session_manager.set_daq_version(version)
-
-    def set_daq_session(self, session: str | Path | None) -> None:
-        """Forward the request to set the DAQ session to the session manager.
-        :param session: the DAQ session to set i.e. "CRT"
-        """
-        self._session_manager.set_daq_session(session)
-
-    # ------------------------------------------------------------------ #
     # Config lifecycle                                                     #
     # ------------------------------------------------------------------ #
     def open_selected_session(self) -> None:
@@ -265,11 +229,11 @@ class RunconfUIBackend:
         self._logger.debug("Opening session")
         self._logger.debug("Loading session")
         self.configuration, self.config_session, init_config_path = (
-            self._session_manager.load_session()
+            self.session_manager.load_session()
         )
 
         self.system_config_reader = SystemConfigReader(
-            self._session_manager.get_runconf_ui_config_path()
+            self.session_manager.get_runconf_ui_config_path()
         )
 
         if self.config_session is None:
@@ -429,7 +393,7 @@ class RunconfUIBackend:
         :param init_config_path: Path to the initial configuration file
         """
         self.info_text = (
-            f"      [bold green]DAQ Version[/bold green]:  [deep_pink4]{self.get_current_version()}[/deep_pink4]\n"
+            f"      [bold green]DAQ Version[/bold green]:  [deep_pink4]{self.session_manager.get_current_version()}[/deep_pink4]\n"
             f"      [bold green]Apparatus[/bold green]:  [deep_pink4]{self.apparatus}[/deep_pink4]\n"
             f"      [bold green]DAQ Config[/bold green]: [deep_pink4]{init_config_path}[/deep_pink4]\n"
             f"      [bold green]Current Config File[/bold green]:  [deep_pink4]{self.configuration.active_database if self.configuration else None}[/deep_pink4]\n"

--- a/src/runconf_ui/backend/runconf_ui_backend.py
+++ b/src/runconf_ui/backend/runconf_ui_backend.py
@@ -56,10 +56,11 @@ TreeViews = dict[str, Tree]
 # ---------------------------------------------------------------------------
 
 
-class _SessionManager:
+class SessionManager:
     """Owns repo interaction and config loading. No state querying here."""
 
     repo_manager: RepoManagerInterface
+    session_manager: "SessionManager" = None  # type: ignore[assignment]
 
     def __init__(self, context: RunconfContext):
         """Session management
@@ -204,7 +205,7 @@ class RunconfUIBackend:
 
         self._logger = get_logger()
 
-        self.session_manager = _SessionManager(context)
+        self.session_manager = SessionManager(context)
         self.apparatus = context.apparatus
 
         self._assembled: AssembledConfig | None = None
@@ -487,7 +488,7 @@ class RunconfUIBackend:
         """
         section_marker = "==============================\n"
 
-        rprint("## Main Tree ##\n")
+        rprint("## Main Tree ##\n", file=text_file)
         rprint(self.get_config_tree(), file=text_file)
         rprint(section_marker, file=text_file)
 

--- a/src/runconf_ui/state_tree/__init__.py
+++ b/src/runconf_ui/state_tree/__init__.py
@@ -1,7 +1,7 @@
 """state_tree"""
 
-from .node_state import NodeState
 from .adapters import AdjustableAttribute, DisableAttribute, DisableComponent
+from .node_state import NodeState
 from .nodes import Group, Leaf, Node
 from .traversal import (
     NodeStatus,
@@ -13,20 +13,18 @@ from .traversal import (
 )
 
 __all__ = [
-    # Adapters
     "AdjustableAttribute",
     "DisableAttribute",
     "DisableComponent",
-    # Nodes
     "Group",
     "Leaf",
     "Node",
-    # Traversal
+    "NodeState",
     "NodeStatus",
-    "node_state",
     "build_index",
     "compute_state",
     "disabled_child_nodes",
     "labelled",
+    "node_state",
     "walk",
 ]

--- a/src/runconf_ui/state_tree/__init__.py
+++ b/src/runconf_ui/state_tree/__init__.py
@@ -1,10 +1,10 @@
 """state_tree"""
 
+from .node_state import NodeState
 from .adapters import AdjustableAttribute, DisableAttribute, DisableComponent
 from .nodes import Group, Leaf, Node
 from .traversal import (
     NodeStatus,
-    State,
     build_index,
     compute_state,
     disabled_child_nodes,
@@ -23,7 +23,7 @@ __all__ = [
     "Node",
     # Traversal
     "NodeStatus",
-    "State",
+    "node_state",
     "build_index",
     "compute_state",
     "disabled_child_nodes",

--- a/src/runconf_ui/state_tree/adapters/attribute_adapters.py
+++ b/src/runconf_ui/state_tree/adapters/attribute_adapters.py
@@ -8,6 +8,7 @@ from runconf_ui.state_tree import NodeState
 
 from .adapter import Adapter
 
+
 class DisableAttribute(Adapter):
     """Adapter for toggling DAL objects by enabling/disabling a named attribute.
 

--- a/src/runconf_ui/state_tree/adapters/attribute_adapters.py
+++ b/src/runconf_ui/state_tree/adapters/attribute_adapters.py
@@ -4,9 +4,9 @@ from conffwk import Configuration
 from conffwk.dal import DalBase
 
 from runconf_ui.exceptions import AttributeMissingException
+from runconf_ui.state_tree import NodeState
 
 from .adapter import Adapter
-
 
 class DisableAttribute(Adapter):
     """Adapter for toggling DAL objects by enabling/disabling a named attribute.
@@ -44,22 +44,24 @@ class DisableAttribute(Adapter):
         self.enabled_value = enabled_value
         self.disabled_value = disabled_value
 
-    def get(self) -> bool:
+    def get(self) -> NodeState:
         """Get the enabled state of the attribute.
 
         :returns: True if attribute equals enabled_value and DAL is enabled as resource
         :rtype: bool
         """
-        return (
-            getattr(self.dal, self.attribute_name) == self.enabled_value
-            and self.dal_enabled()
-        )
+        is_enabled = getattr(self.dal, self.attribute_name) == self.enabled_value and self.dal_enabled()
+        return NodeState.bool_to_state(is_enabled)
 
-    def set(self, value: bool) -> None:
+    def set(self, value: bool | NodeState) -> None:
         """Set the enabled state by toggling the attribute value.
 
         :param value: True to set enabled_value, False to set disabled_value
         """
+        
+        if isinstance(value, NodeState):
+            value = NodeState.state_to_bool(value)
+        
         new_value = self.enabled_value if value else self.disabled_value
         if getattr(self.dal, self.attribute_name) != new_value:
             setattr(self.dal, self.attribute_name, new_value)

--- a/src/runconf_ui/state_tree/adapters/attribute_adapters.py
+++ b/src/runconf_ui/state_tree/adapters/attribute_adapters.py
@@ -4,8 +4,8 @@ from conffwk import Configuration
 from conffwk.dal import DalBase
 
 from runconf_ui.exceptions import AttributeMissingException
-from runconf_ui.state_tree import NodeState
 
+from ..node_state import NodeState
 from .adapter import Adapter
 
 

--- a/src/runconf_ui/state_tree/adapters/component_adapter.py
+++ b/src/runconf_ui/state_tree/adapters/component_adapter.py
@@ -3,8 +3,8 @@ from conffwk.dal import DalBase
 from confmodel_dal import disable_component, enable_component
 
 from runconf_ui.exceptions import IncompatibleDalException
-from runconf_ui.state_tree import NodeState
 
+from ..node_state import NodeState
 from .adapter import Adapter
 
 # Set up some class colours dynamically

--- a/src/runconf_ui/state_tree/adapters/component_adapter.py
+++ b/src/runconf_ui/state_tree/adapters/component_adapter.py
@@ -3,8 +3,11 @@ from conffwk.dal import DalBase
 from confmodel_dal import disable_component, enable_component
 
 from runconf_ui.exceptions import IncompatibleDalException
+from runconf_ui.state_tree import NodeState
 
 from .adapter import Adapter
+
+# Set up some class colours dynamically
 
 
 class DisableComponent(Adapter):
@@ -35,19 +38,23 @@ class DisableComponent(Adapter):
         self.label = label
         super().__init__(configuration, session, dal)
 
-    def get(self) -> bool:
+    def get(self) -> NodeState:
         """Get the enabled state of the component.
 
         :returns: True if the component is enabled as a resource, False otherwise
         :rtype: bool
         """
-        return self.dal_enabled()
+        return NodeState.bool_to_state(self.dal_enabled())
+        
 
-    def set(self, value: bool) -> None:
+    def set(self, value: bool|NodeState) -> None:
         """Set the enabled state of the component.
 
         :param value: True to enable the component, False to disable
         """
+        if isinstance(value, NodeState):
+            value = NodeState.state_to_bool(value)
+        
         if value:
             enable_component(self.configuration._obj, self.session.id, self.dal.id)
         else:

--- a/src/runconf_ui/state_tree/node_state.py
+++ b/src/runconf_ui/state_tree/node_state.py
@@ -33,8 +33,7 @@ class NodeState(Enum):
         
         if state_bool:
             return NodeState.ENABLED
-        else:
-            return NodeState.DISABLED
+        return NodeState.DISABLED
         
     @staticmethod
     def state_to_bool(state: "NodeState")->bool:

--- a/src/runconf_ui/state_tree/node_state.py
+++ b/src/runconf_ui/state_tree/node_state.py
@@ -28,6 +28,9 @@ class NodeState(Enum):
 
     @staticmethod
     def bool_to_state(state_bool: bool)->"NodeState":
+        if isinstance(state_bool, NodeState):
+            return state_bool
+        
         if state_bool:
             return NodeState.ENABLED
         else:
@@ -35,4 +38,6 @@ class NodeState(Enum):
         
     @staticmethod
     def state_to_bool(state: "NodeState")->bool:
-        return state==NodeState.ENABLED or state==NodeState.PARTIALLY_ENABLED
+        if isinstance(state, bool):
+            return state
+        return state in {NodeState.ENABLED, NodeState.PARTIALLY_ENABLED}

--- a/src/runconf_ui/state_tree/node_state.py
+++ b/src/runconf_ui/state_tree/node_state.py
@@ -1,0 +1,38 @@
+'''
+State enum
+'''
+from enum import Enum, auto
+
+
+class NodeState(Enum):
+    """The state of a node."""
+    ENABLED = (auto(), "#39b039")
+    DISABLED = (auto(), "#808080")
+    PARTIALLY_ENABLED=(auto(), "#d78700")
+    PARENT_DISABLED = (auto(), "#808080")
+    ERROR_STATE = (auto(), "#d70000")
+
+    def __str__(self) -> str:
+        return self.name
+    
+    def __repr__(self)->str:
+        return self.name.lower().replace("_", " ")
+
+    @property
+    def idx(self):
+        return self.value[0]
+    
+    @property
+    def colour(self):
+        return self.value[1]
+
+    @staticmethod
+    def bool_to_state(state_bool: bool)->"NodeState":
+        if state_bool:
+            return NodeState.ENABLED
+        else:
+            return NodeState.DISABLED
+        
+    @staticmethod
+    def state_to_bool(state: "NodeState")->bool:
+        return state==NodeState.ENABLED or state==NodeState.PARTIALLY_ENABLED

--- a/src/runconf_ui/state_tree/nodes.py
+++ b/src/runconf_ui/state_tree/nodes.py
@@ -75,7 +75,7 @@ class Leaf(Node):
     Wraps a single Adapter. The only node type that reads/writes conffwk.
     Reports its own raw adapter value; gating by parent is handled in traversal.
     """
-
+    
     def __init__(self, adapter: Adapter, label: str = "", tooltip: str = ""):
         """Initialize a Leaf node.
 
@@ -136,15 +136,13 @@ class Group(Node):
 
         :param node: The child node to add
         :returns: self for method chaining
-        :rtype: Group
+        :rtype: Groupx
         """
         self.children.append(node)
         return self
 
     def at(self, *path: str) -> "Group":
         """Find or create a chain of named child Groups, returning the deepest.
-
-
         :param path: Hierarchical path labels for nested groups
         :returns: The deepest group in the created/found chain
         :rtype: Group
@@ -172,8 +170,12 @@ class Group(Node):
         """Propagate state to all children who can be toggled
         """
         for child in self.children:
-            if isinstance(child.get(), NodeState):            
+            if isinstance(child.get(), NodeState):
                 child.set(value)
+    
+    @property
+    def top_level_leaves(self):
+        return [c for c in self.children if isinstance(c, Leaf)]
 
     # ------------------------------------------------------------------ #
     # Read path                                                            #
@@ -181,9 +183,18 @@ class Group(Node):
     def get(self) -> NodeState:
         """Get the aggregated state of all nodes."""
         child_states = [c.get() for c in self.children]
+        
+        if not child_states:
+            return NodeState.DISABLED
 
         if NodeState.ERROR_STATE in child_states:
             return NodeState.ERROR_STATE
+
+
+        top_states = [not NodeState.state_to_bool(l.get()) for l in self.top_level_leaves if isinstance(l.get(), NodeState)]
+
+        if all(top_states) and top_states:
+            return NodeState.DISABLED
 
         first_state = child_states[0]
         if all(s == first_state for s in child_states):

--- a/src/runconf_ui/state_tree/nodes.py
+++ b/src/runconf_ui/state_tree/nodes.py
@@ -16,41 +16,19 @@ Every node has:
   label:   str — display name for rendering and index lookup.
                  Empty string means anonymous (not shown in the UI).
   tooltip: str — text shown on hover in the UI. Empty string means no tooltip.
-
-Children are stored as _Child entries carrying two flags:
-
-  votes: bool      — does this child's state contribute to the parent's
-                     aggregated state?
-                     False for adjustable nodes and controlled-but-non-voting
-                     components.
-
-  propagate: bool  — should Group.set() reach this child?
-                     False for adjustable nodes, whose values are set directly
-                     via their adapter and must not receive a bool from the
-                     enable/disable tree.
-                     True for all disable nodes, voting or not.
-
-The two flags are independent:
-
-  votes=True,  propagate=True  — normal voting disable child (default)
-  votes=False, propagate=True  — gated by parent, doesn't influence it
-                                 (replaces the old controlled_objects mechanism)
-  votes=False, propagate=False — adjustable child: organisationally grouped
-                                 here but fully independent of enable/disable
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Iterator
-from dataclasses import dataclass
+from collections.abc import Iterator
 from typing import Any
+
+from .node_state import NodeState
 
 from .adapters.adapter import Adapter
 
 # ---------------------------------------------------------------------------
 # Base
 # ---------------------------------------------------------------------------
-
-
 class Node(ABC):
     """Base class for all tree nodes.
 
@@ -124,56 +102,18 @@ class Leaf(Node):
 
 
 # ---------------------------------------------------------------------------
-# Child entry
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class _Child:
-    """Internal representation of a child node with voting and propagation flags."""
-
-    node: Node
-    votes: bool
-    propagate: bool
-
-
-# ---------------------------------------------------------------------------
 # Group
 # ---------------------------------------------------------------------------
 
 
 class Group(Node):
     """
-    Aggregates the state of its children.
-
-    strategy is a callable over an iterable of bools:
-      all — enabled iff every voting child is enabled (AND semantics)
-      any — enabled if any voting child is enabled  (OR semantics)
-
-    Children added with votes=False do not contribute to the aggregated state
-    but are still gated by it (they appear disabled when the parent is off).
-
-    Children added with propagate=False are not reached by set() — used for
-    adjustable nodes whose values are managed directly via their adapter.
-
-    Usage:
-        group = Group("TPC", strategy=all)
-        group.add(segment_leaf)
-        group.add(tpg_leaf, votes=False)
-
-        # Adjustable node — grouped here but independent of enable/disable:
-        group.add(rate_leaf, votes=False, propagate=False)
-
-        # Fluent subsystem creation:
-        group.at("CRP4").add(crp4_leaf).add(crp4_tpg, votes=False)
-        group.at("CRP4", "TPG").add(deep_leaf)
+    Group of nodes
     """
-
     def __init__(
         self,
         label: str = "",
         tooltip: str = "",
-        strategy: Callable[[Iterable[bool]], bool] = all,
     ):
         """Initialize a Group node.
 
@@ -182,8 +122,7 @@ class Group(Node):
         :param strategy: Callable to aggregate child states (all or any)
         """
         super().__init__(label, tooltip)
-        self.strategy = strategy
-        self._children: list[_Child] = []
+        self.children: list[Node] = []
 
     # ------------------------------------------------------------------ #
     # Write path                                                           #
@@ -192,24 +131,19 @@ class Group(Node):
     def add(
         self,
         node: Node,
-        votes: bool = True,
-        propagate: bool = True,
     ) -> "Group":
         """Add a child node. Returns self for method chaining.
 
         :param node: The child node to add
-        :param votes: Whether this child's state influences parent's aggregated state
-        :param propagate: Whether this child receives set() calls from parent
         :returns: self for method chaining
         :rtype: Group
         """
-        self._children.append(_Child(node=node, votes=votes, propagate=propagate))
+        self.children.append(node)
         return self
 
     def at(self, *path: str) -> "Group":
         """Find or create a chain of named child Groups, returning the deepest.
 
-        Creates any missing intermediate groups with strategy=any.
 
         :param path: Hierarchical path labels for nested groups
         :returns: The deepest group in the created/found chain
@@ -227,91 +161,51 @@ class Group(Node):
         :returns: Existing or newly created subgroup
         :rtype: Group
         """
-        for child in self._children:
-            if isinstance(child.node, Group) and child.node.label == label:
-                return child.node
-        subgroup = Group(label=label, strategy=any)
-        self.add(subgroup, votes=True, propagate=True)
+        for child in self.children:
+            if isinstance(child, Group) and child.label == label:
+                return child
+        subgroup = Group(label=label)
+        self.add(subgroup)
         return subgroup
 
-    def set(self, value: bool) -> None:
-        """Propagate state to all children where propagate=True.
-
-        Adjustable nodes (propagate=False) are never touched.
-
-        :param value: The value to propagate to children
+    def set(self, value: bool | NodeState) -> None:
+        """Propagate state to all children who can be toggled
         """
-        for child in self._children:
-            if child.propagate:
-                child.node.set(value)
+        for child in self.children:
+            if isinstance(child.get(), NodeState):            
+                child.set(value)
 
     # ------------------------------------------------------------------ #
     # Read path                                                            #
-    # ------------------------------------------------------------------ #
+    # ------------------------------------------------------------------ 
+    def get(self) -> NodeState:
+        """Get the aggregated state of all nodes."""
+        child_states = [c.get() for c in self.children]
 
-    def get(self) -> bool:
-        """Get the aggregated state of voting children.
+        if NodeState.ERROR_STATE in child_states:
+            return NodeState.ERROR_STATE
 
-        Returns True vacuously when there are no voting children.
+        first_state = child_states[0]
+        if all(s == first_state for s in child_states):
+            return first_state
 
-        HAS A MAJOR SIDE EFFECT: Propagates the state to non-voting nodes
+        if not isinstance(first_state, NodeState):
+            return NodeState.ERROR_STATE
 
-        :returns: Aggregated state based on strategy (all or any)
-        :rtype: bool
-        """
-        voting = self.voting_children
-        if not voting:
-            return True
-        state = self.strategy(child.get() for child in voting)
+        if NodeState.ENABLED in child_states or NodeState.PARTIALLY_ENABLED in child_states:
+            return NodeState.PARTIALLY_ENABLED
 
-        # Propagate to non-voting nodes
-        for child in self._children:
-            if child.propagate and not child.votes:
-                child.node.set(state)
-
-        return state
-
-    def gated_get(self, child: Node) -> bool:
-        """Return the visible state of a direct child, gated by this group.
-
-        If this group is disabled the child reports disabled regardless of
-        its own stored state.
-
-        :param child: The child node to get the gated state for
-        :returns: Gated state of the child
-        :rtype: bool
-        """
-        if not self.get():
-            return False
-        return child.get()
+        return NodeState.ERROR_STATE
 
     # ------------------------------------------------------------------ #
     # Structural access                                                    #
     # ------------------------------------------------------------------ #
 
-    def __iter__(self) -> Iterator[tuple[Node, bool, bool]]:
-        """Iterate over (child, votes, propagate) triples.
+    def __iter__(self) -> Iterator[Node]:
+        """Iterate over child nodes.
 
         :returns: Iterator of child node information tuples
-        :rtype: Iterator[tuple[Node, bool, bool]]
+        :rtype: Iterator[Node]
         """
-        for c in self._children:
-            yield c.node, c.votes, c.propagate
-
-    @property
-    def voting_children(self) -> list[Node]:
-        """Get list of children that vote in parent's aggregated state.
-
-        :returns: List of voting child nodes
-        :rtype: list[Node]
-        """
-        return [c.node for c in self._children if c.votes]
-
-    @property
-    def children(self) -> list[Node]:
-        """Get list of all children.
-
-        :returns: List of all child nodes
-        :rtype: list[Node]
-        """
-        return [c.node for c in self._children]
+        for c in self.children:
+            yield c

--- a/src/runconf_ui/state_tree/nodes.py
+++ b/src/runconf_ui/state_tree/nodes.py
@@ -174,8 +174,8 @@ class Group(Node):
                 child.set(value)
     
     @property
-    def top_level_leaves(self):
-        return [c for c in self.children if isinstance(c, Leaf)]
+    def top_level_groups(self):
+        return [c for c in self.children if isinstance(c, Group)]
 
     # ------------------------------------------------------------------ #
     # Read path                                                            #
@@ -191,11 +191,12 @@ class Group(Node):
             return NodeState.ERROR_STATE
 
 
-        top_states = [not NodeState.state_to_bool(i.get()) for i in self.top_level_leaves if isinstance(i.get(), NodeState)]
+        top_groups = [not NodeState.state_to_bool(g.get()) for g in self.top_level_groups]
 
-        if all(top_states) and top_states:
+        if all(top_groups) and top_groups:
             return NodeState.DISABLED
 
+        # Now we check 
         first_state = child_states[0]
         if all(s == first_state for s in child_states):
             return first_state

--- a/src/runconf_ui/state_tree/nodes.py
+++ b/src/runconf_ui/state_tree/nodes.py
@@ -22,9 +22,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import Any
 
+from .adapters.adapter import Adapter
 from .node_state import NodeState
 
-from .adapters.adapter import Adapter
 
 # ---------------------------------------------------------------------------
 # Base
@@ -191,7 +191,7 @@ class Group(Node):
             return NodeState.ERROR_STATE
 
 
-        top_states = [not NodeState.state_to_bool(l.get()) for l in self.top_level_leaves if isinstance(l.get(), NodeState)]
+        top_states = [not NodeState.state_to_bool(i.get()) for i in self.top_level_leaves if isinstance(i.get(), NodeState)]
 
         if all(top_states) and top_states:
             return NodeState.DISABLED
@@ -218,5 +218,4 @@ class Group(Node):
         :returns: Iterator of child node information tuples
         :rtype: Iterator[Node]
         """
-        for c in self.children:
-            yield c
+        yield from self.children

--- a/src/runconf_ui/state_tree/traversal.py
+++ b/src/runconf_ui/state_tree/traversal.py
@@ -31,6 +31,7 @@ from runconf_ui.utils.logging import get_logger
 
 from .nodes import Group, Leaf, Node
 
+
 @dataclass
 class NodeStatus:
     """A full node status, carrying the node, its computed state, and its parent."""

--- a/src/runconf_ui/state_tree/traversal.py
+++ b/src/runconf_ui/state_tree/traversal.py
@@ -42,7 +42,7 @@ class NodeStatus:
     @property
     def is_interactive(self) -> bool:
         """False when the node is greyed out due to parent or DAL state."""
-        return self.state not in (NodeState.PARENT_DISABLED, NodeState.ERROR_STATE)
+        return self.parent is None or NodeState.state_to_bool(self.parent.get())
 
     @property
     def path(self) -> str | None:
@@ -104,15 +104,16 @@ def compute_state(node: Node, parent: Group | None) -> NodeState:
     :returns: The computed state
     :rtype: State
     """
-    # 1. Parent gating takes precedence over everything.
-    if parent is not None and not NodeState.state_to_bool(parent.get()):
+    parent_gated = (
+        parent is not None
+        and not NodeState.state_to_bool(parent.get())
+        and (all(not NodeState.state_to_bool(s.get()) for s in parent.top_level_leaves) if parent.top_level_leaves else True)
+    )
+    dal_disabled = isinstance(node, Leaf) and not node.adapter.dal_enabled()
+
+    if parent_gated or dal_disabled:
         return NodeState.PARENT_DISABLED
 
-    # 2. Leaf DAL resource state.
-    if isinstance(node, Leaf) and not node.adapter.dal_enabled():
-        return NodeState.PARENT_DISABLED
-
-    # 3. Node's own internal value.
     return node.get()
 
 # ---------------------------------------------------------------------------

--- a/src/runconf_ui/state_tree/traversal.py
+++ b/src/runconf_ui/state_tree/traversal.py
@@ -25,42 +25,24 @@ consulted when its parent (if any) is enabled.
 
 from collections.abc import Iterator
 from dataclasses import dataclass
-from enum import Enum, auto
 
+from runconf_ui.state_tree.node_state import NodeState
 from runconf_ui.utils.logging import get_logger
 
 from .nodes import Group, Leaf, Node
-
-# ---------------------------------------------------------------------------
-# State
-# ---------------------------------------------------------------------------
-
-
-class State(Enum):
-    """The state of a node."""
-
-    ENABLED = auto()
-    DISABLED = auto()
-    PARENT_DISABLED = auto()
-
 
 @dataclass
 class NodeStatus:
     """A full node status, carrying the node, its computed state, and its parent."""
 
     node: Node
-    state: State
+    state: NodeState
     parent: Group | None
 
     @property
     def is_interactive(self) -> bool:
         """False when the node is greyed out due to parent or DAL state."""
-        return self.state != State.PARENT_DISABLED
-
-    @property
-    def is_enabled(self) -> bool:
-        """True only when the node is fully enabled."""
-        return self.state == State.ENABLED
+        return self.state not in (NodeState.PARENT_DISABLED, NodeState.ERROR_STATE)
 
     @property
     def path(self) -> str | None:
@@ -87,7 +69,9 @@ class NodeStatus:
 
         Only works when is_interactive is True (not PARENT_DISABLED).
         """
-        self.node.set(not self.node.get())
+        if self.state != NodeState.ERROR_STATE:    
+            self.node.set(not NodeState.state_to_bool(self.state))
+
         get_logger().debug(f"Toggling {self.label}")
 
         self.refresh_state()
@@ -106,7 +90,7 @@ class NodeStatus:
 # ---------------------------------------------------------------------------
 
 
-def compute_state(node: Node, parent: Group | None) -> State:
+def compute_state(node: Node, parent: Group | None) -> NodeState:
     """Compute the visible state of a node.
 
     Precedence (highest first):
@@ -121,26 +105,22 @@ def compute_state(node: Node, parent: Group | None) -> State:
     :rtype: State
     """
     # 1. Parent gating takes precedence over everything.
-    if parent is not None and not parent.get():
-        return State.PARENT_DISABLED
+    if parent is not None and not NodeState.state_to_bool(parent.get()):
+        return NodeState.PARENT_DISABLED
 
     # 2. Leaf DAL resource state.
     if isinstance(node, Leaf) and not node.adapter.dal_enabled():
-        return State.PARENT_DISABLED
+        return NodeState.PARENT_DISABLED
 
     # 3. Node's own internal value.
-    if not node.get():
-        return State.DISABLED
-
-    return State.ENABLED
-
+    return node.get()
 
 # ---------------------------------------------------------------------------
 # Traversal
 # ---------------------------------------------------------------------------
 
 
-def walk(root: Node, parent: Group | None = None, _ancestor_disabled: bool = False):
+def walk(root: Node, parent: Group | None = None, _ancestor_state: NodeState = NodeState.ENABLED):
     """Depth-first traversal of the node tree, yielding NodeStatus for every node.
 
     Yields NodeStatus objects containing the state of each node in the tree.
@@ -153,18 +133,18 @@ def walk(root: Node, parent: Group | None = None, _ancestor_disabled: bool = Fal
     :returns: Iterator of NodeStatus objects
     :rtype: Iterator[NodeStatus]
     """
-    state = compute_state(root, parent if not _ancestor_disabled else None)
-    if _ancestor_disabled:
-        state = State.PARENT_DISABLED
+    state = compute_state(root, parent if not _ancestor_state else None)
+    if not NodeState.state_to_bool(_ancestor_state):
+        state = NodeState.PARENT_DISABLED
 
     # We can also set the state here
     yield NodeStatus(root, state, parent)
 
     if isinstance(root, Group):
-        child_ancestor_disabled = _ancestor_disabled or state == State.PARENT_DISABLED
-        for child, _, _ in root:
+        child_ancestor_disabled = NodeState.state_to_bool(_ancestor_state) or NodeState.state_to_bool(state)
+        for child in root:
             yield from walk(
-                child, parent=root, _ancestor_disabled=child_ancestor_disabled
+                child, parent=root, _ancestor_state=NodeState.bool_to_state(child_ancestor_disabled)
             )
 
 
@@ -194,14 +174,12 @@ def disabled_child_nodes(group: Group) -> list[Node]:
     :returns: List of disabled voting child nodes
     :rtype: list[Node]
     """
-    return [n for n in group.voting_children if not n.get()]
+    return [n for n in group.children if not NodeState.state_to_bool(n.get())]
 
 
 # ---------------------------------------------------------------------------
 # Index
 # ---------------------------------------------------------------------------
-
-
 def build_index(root: Node) -> dict[str, Node]:
     """Build a flat label->node mapping for O(1) lookup by label.
 

--- a/src/runconf_ui/state_tree/traversal.py
+++ b/src/runconf_ui/state_tree/traversal.py
@@ -43,7 +43,13 @@ class NodeStatus:
     @property
     def is_interactive(self) -> bool:
         """False when the node is greyed out due to parent or DAL state."""
-        return self.parent is None or NodeState.state_to_bool(self.parent.get())
+        if self.parent is None:
+            return True
+        
+        if not self.parent.top_level_groups:
+            return True
+        
+        return NodeState.state_to_bool(self.parent.get()) 
 
     @property
     def path(self) -> str | None:
@@ -108,7 +114,7 @@ def compute_state(node: Node, parent: Group | None) -> NodeState:
     parent_gated = (
         parent is not None
         and not NodeState.state_to_bool(parent.get())
-        and (all(not NodeState.state_to_bool(s.get()) for s in parent.top_level_leaves) if parent.top_level_leaves else True)
+        and (all(not NodeState.state_to_bool(s.get()) for s in parent.top_level_groups) if parent.top_level_groups else True)
     )
     dal_disabled = isinstance(node, Leaf) and not node.adapter.dal_enabled()
 

--- a/src/runconf_ui/system_configuration/builders.py
+++ b/src/runconf_ui/system_configuration/builders.py
@@ -95,36 +95,27 @@ class DisableSystemBuilder:
         :returns: The constructed Group tree
         :rtype: Group
         """
-        root_strategy = any if system.subsystem_dependent else all
-        root = Group(label=label, strategy=root_strategy)
+        root = Group(label=label)
 
         for comp in system.components:
             get_logger().debug(f"            - adding component: {comp} ")
-            self._add_component(root, comp, system.subsystem_dependent)
+            self._add_component(root, comp)
 
         for attr in system.attributes:
             get_logger().debug(f"            - adding attribute: {attr} ")
-            self._add_attribute(root, attr, system.subsystem_dependent)
+            self._add_attribute(root, attr)
 
         for rel in system.relationships:
             get_logger().debug(f"            - adding relationship: {rel} ")
-            self._add_relationship(root, rel, system.subsystem_dependent)
+            self._add_relationship(root, rel)
 
         return root
 
     # ------------------------------------------------------------------ #
-    def _votes(self, subsystem_dependent: bool, has_own_label: bool) -> bool:
-        """
-        A child votes iff the system is not subsystem_dependent, or the child
-        has its own named label (i.e. it is itself a named subsystem).
-        """
-        return not subsystem_dependent or has_own_label
-
     def _add_component(
         self,
         root: Group,
         comp: DisableElementData,
-        subsystem_dependent: bool,
     ) -> None:
         """Add component nodes to the root group.
 
@@ -138,29 +129,23 @@ class DisableSystemBuilder:
 
         for node in nodes:
             if comp.each_component_separate:
-                # Wrap each leaf in a named container Group.
-                # The leaf's label is cleared so only the Group appears as a button.
-                # votes=False on root → root stays vacuously True, never gating siblings.
-                # propagate=True on root → toggling root still reaches all containers.
-                wrapper = Group(label=comp.system_label or node.label, strategy=any)
+                wrapper = Group(label=comp.system_label or node.label)
                 node.label = ""
-                wrapper.add(node, votes=True, propagate=True)
-                root.add(wrapper, votes=False, propagate=True)
+                wrapper.add(node)
+                root.add(wrapper)
             else:
                 label = comp.system_label or (
                     node.label if comp.separate_system else ""
                 )
-                votes = self._votes(subsystem_dependent, bool(label))
                 if label:
-                    root.at(label).add(node, votes=True, propagate=True)
+                    root.at(label).add(node)
                 else:
-                    root.add(node, votes=votes, propagate=True)
+                    root.add(node)
 
     def _add_attribute(
         self,
         root: Group,
         attr: DisableAttributeData,
-        subsystem_dependent: bool,
     ) -> None:
         """Add attribute nodes to the root group.
 
@@ -173,18 +158,16 @@ class DisableSystemBuilder:
             return
 
         label = attr.system_label
-        votes = self._votes(subsystem_dependent, bool(label or attr.separate_system))
 
         if label:
-            root.at(label).add(node, votes=True, propagate=True)
+            root.at(label).add(node)
         else:
-            root.add(node, votes=votes, propagate=True)
+            root.add(node)
 
     def _add_relationship(
         self,
         root: Group,
         rel: DisableRelationshipData,
-        subsystem_dependent: bool,
     ) -> None:
         """Add relationship nodes to the root group.
 
@@ -197,12 +180,11 @@ class DisableSystemBuilder:
             return
 
         label = rel.system_label
-        votes = self._votes(subsystem_dependent, bool(label or rel.separate_system))
 
         if label:
-            root.at(label).add(node, votes=True, propagate=True)
+            root.at(label).add(node)
         else:
-            root.add(node, votes=votes, propagate=True)
+            root.add(node)
 
 
 # ---------------------------------------------------------------------------
@@ -213,12 +195,6 @@ class DisableSystemBuilder:
 class AdjustableSystemBuilder:
     """
     Builds a Group tree from a list of AdjustableAttributeData instances.
-
-    All children use votes=False, propagate=False — they are never touched
-    by Group.set() and do not influence any parent's aggregated state.
-    Their visible state (ENABLED / PARENT_DISABLED) is computed by
-    compute_state() in traversal.py based on parent group state and
-    DAL resource state.
     """
 
     def __init__(self, configuration: Configuration, session: DalBase):
@@ -228,7 +204,6 @@ class AdjustableSystemBuilder:
         :param session: The session DAL object
         """
         get_logger().debug("Initialising AdjustableSystemBuilder")
-
         self.factory = AdjustableFactory(configuration, session)
 
     def build(self, attributes: list[AdjustableAttributeData], label: str) -> Group:
@@ -239,16 +214,14 @@ class AdjustableSystemBuilder:
         :returns: The constructed Group tree
         :rtype: Group
         """
-        root = Group(label=label, strategy=all)
+        root = Group(label=label)
         get_logger().debug("Building adjustable attributes")
 
         for attr in attributes:
             get_logger().debug(f"    - Building {attr}")
 
             nodes = self.factory.create(attr)
-            if not nodes:
-                continue
-            for node in nodes:
-                root.add(node, votes=False, propagate=False)
+            for node in nodes or []:
+                root.add(node)
 
         return root

--- a/src/runconf_ui/system_configuration/builders.py
+++ b/src/runconf_ui/system_configuration/builders.py
@@ -129,10 +129,10 @@ class DisableSystemBuilder:
 
         for node in nodes:
             if comp.each_component_separate:
-                wrapper = Group(label=comp.system_label or node.label)
-                node.label = ""
-                wrapper.add(node)
-                root.add(wrapper)
+                # wrapper = Group(label=comp.system_label or node.label)
+                # node.label = ""
+                # wrapper.add(node)
+                root.add(node)
             else:
                 label = comp.system_label or (
                     node.label if comp.separate_system else ""

--- a/src/runconf_ui/system_configuration/config_reader.py
+++ b/src/runconf_ui/system_configuration/config_reader.py
@@ -17,7 +17,7 @@ import yaml
 from conffwk import Configuration
 from conffwk.dal import DalBase
 
-from runconf_ui.state_tree import Group, NodeStatus, walk
+from runconf_ui.state_tree import Group, NodeStatus, walk, NodeState
 from runconf_ui.utils import get_logger
 
 from .builders import AdjustableSystemBuilder, DisableSystemBuilder
@@ -33,7 +33,7 @@ from .dataclasses import (
 
 
 def _natural_key(s: str):
-    """Convert a string into a list suitable for natural sorting.
+    """Convert a string into a list suitable for naturalf sorting.
 
     :param s: String to convert
     :returns: List of integers and strings for natural sort order
@@ -55,7 +55,7 @@ def _node_sort_key(item: tuple[str, NodeStatus]):
     """
     key, node = item
     return (
-        0 if node.is_enabled else 1,
+        0 if NodeState.state_to_bool(node.state) else 1,
         _natural_key(key),
     )
 

--- a/src/runconf_ui/system_configuration/config_reader.py
+++ b/src/runconf_ui/system_configuration/config_reader.py
@@ -17,7 +17,7 @@ import yaml
 from conffwk import Configuration
 from conffwk.dal import DalBase
 
-from runconf_ui.state_tree import Group, NodeStatus, walk, NodeState
+from runconf_ui.state_tree import Group, NodeState, NodeStatus, walk
 from runconf_ui.utils import get_logger
 
 from .builders import AdjustableSystemBuilder, DisableSystemBuilder

--- a/src/runconf_ui/system_configuration/factories/attribute_factory.py
+++ b/src/runconf_ui/system_configuration/factories/attribute_factory.py
@@ -16,7 +16,7 @@ TDisableAttributeData = TypeVar("TDisableAttributeData", bound=DisableAttributeD
 class AttributeFactory(FactoryBase[TDisableAttributeData, "Group | None"]):
     """Creates a Group node containing Leaf nodes for disable attributes.
 
-    Creates a Group node (strategy=any) containing one Leaf per matching DAL.
+    Creates a Group node containing one Leaf per matching DAL.
     OR semantics: the attribute group is considered enabled if any DAL has
     the attribute enabled.
     """
@@ -36,7 +36,7 @@ class AttributeFactory(FactoryBase[TDisableAttributeData, "Group | None"]):
         if not dal_list:
             return None
 
-        group = Group(strategy=any)
+        group = Group()
         for dal in dal_list:
             if not self.is_filtered(dal, data.filters):
                 group.add(

--- a/src/runconf_ui/textual/runconf_shifter_ui.tcss
+++ b/src/runconf_ui/textual/runconf_shifter_ui.tcss
@@ -150,20 +150,6 @@ EnableDisableButtonScroller {
     color: white;
 }
 
-.node_enabled,
-.detector_subsystem_button_enabled {
-    background: $success;
-}
-
-.node_disabled,
-.detector_subsystem_button_disabled {
-    background: $panel-darken-2;
-}
-
-.detector_subsystem_button_partial {
-    background: $warning-lighten-2;
-}
-
 
 /* ============================================================
    Adjustable Attribute Panel

--- a/src/runconf_ui/textual/runconf_ui_app.py
+++ b/src/runconf_ui/textual/runconf_ui_app.py
@@ -27,10 +27,12 @@ from runconf_ui.textual.widgets import (
     OptionsPanel,
     RichTreeTabbed,
 )
+from runconf_ui.state_tree import NodeState
 from runconf_ui.utils import get_logger
 
 # No neat way to type this sadly
 NodeIterator = list[tuple[DOMQuery, Any]]
+
 
 
 class RunconfUIApp(App):
@@ -75,6 +77,8 @@ class RunconfUIApp(App):
         Sets theme, title, and initializes file selectors.
         """
         get_logger().debug("Mounting")
+
+        self._install_node_state_css()
         self.theme = "catppuccin-latte"
         self.title = f"Runconf-Shifter-UI v{version('runconf_ui')}"
         self.switch_mode("main")
@@ -95,8 +99,8 @@ class RunconfUIApp(App):
     @work(thread=True)
     def _fetch_sessions_worker(self, daq_version) -> None:
         try:
-            self.backend.set_daq_version(daq_version)  # ← moved into worker
-            sessions = self.backend.get_sessions()
+            self.backend.session_manager.set_daq_version(daq_version)  # ← moved into worker
+            sessions = self.backend.session_manager.get_sessions()
             get_logger().debug(f"Available Sessions: {sessions}")
             self.app.call_from_thread(self._apply_sessions, sessions)
         except Exception as e:
@@ -115,7 +119,7 @@ class RunconfUIApp(App):
 
     @on(runconf_msg.DaqSessionSelectedMessage)
     def handle_session_selected(self, event: runconf_msg.DaqSessionSelectedMessage):
-        self.backend.set_daq_session(event.daq_session)
+        self.backend.session_manager.set_daq_session(event.daq_session)
         get_logger().info(f"Selected daq session: {event.daq_session}")
         for file_select in self.query(FileSelect):
             file_select.enable_open_button()
@@ -248,14 +252,29 @@ class RunconfUIApp(App):
 
     def _init_file_selects(self) -> None:
         try:
-            versions = self.backend.get_daq_versions()
+            versions = self.backend.session_manager.get_daq_versions()
             get_logger().debug(f"Initialising file selects with {versions}")
             for file_select in self.query(FileSelect):
                 file_select.update_versions(versions)
-                file_select.set_default_version(self.backend.get_default_version())
+                file_select.set_default_version(self.backend.session_manager.get_default_version())
                 file_select.refresh()
         except Exception as e:
             get_logger().exception(e)
             self.handle_exception_popup(e)
         finally:
             self.pop_screen()
+   
+    def _install_node_state_css(self) -> None:
+        """Install CSS rules for the fixed NodeState colours."""
+
+        css = "\n".join(
+            f"""
+            .node-state-{state.name.lower()} {{
+                background: {state.colour};
+                color: white;
+            }}
+            """
+            for state in NodeState
+        )
+
+        self.stylesheet.add_source(css)

--- a/src/runconf_ui/textual/runconf_ui_app.py
+++ b/src/runconf_ui/textual/runconf_ui_app.py
@@ -10,6 +10,7 @@ from textual.app import App
 from textual.css.query import DOMQuery
 
 from runconf_ui.backend import RunconfUIBackend
+from runconf_ui.state_tree import NodeState
 from runconf_ui.textual import messages as runconf_msg
 from runconf_ui.textual.screens import (
     CreateScreen,
@@ -27,7 +28,6 @@ from runconf_ui.textual.widgets import (
     OptionsPanel,
     RichTreeTabbed,
 )
-from runconf_ui.state_tree import NodeState
 from runconf_ui.utils import get_logger
 
 # No neat way to type this sadly

--- a/src/runconf_ui/textual/widgets/enable_disable_panel.py
+++ b/src/runconf_ui/textual/widgets/enable_disable_panel.py
@@ -2,7 +2,7 @@ from textual import on
 from textual.containers import ScrollableContainer, Vertical
 from textual.widgets import Button, Static
 
-from runconf_ui.state_tree import NodeStatus
+from runconf_ui.state_tree import NodeStatus, NodeState
 from runconf_ui.utils import get_logger
 
 from ..messages import NodeToggledMessage
@@ -56,19 +56,20 @@ class EnableDisablePanel(Vertical):
         for node_id, node in self._runconf_nodes.items():
             get_logger().debug(f"   - {node_id} : {node}")
 
-            enabled_state = "node_enabled" if node.is_enabled else "node_disabled"
             is_top = node.parent is None
 
             node_classes = (
-                f"{main_node_label if is_top else sub_node_label} {enabled_state}"
+                f"{main_node_label if is_top else sub_node_label}"
             )
+
+            state_class = f"node-state-{node.state.name.lower()}"
 
             btn = Button(
                 label=node.node.label,
                 id=node_id,
-                classes=node_classes,
+                classes=f"{node_classes} {state_class}",
                 disabled=not node.is_interactive,
-            )
+)            
             if node.tooltip:
                 btn.tooltip = node.tooltip
 
@@ -130,8 +131,16 @@ class EnableDisablePanel(Vertical):
                 continue
             get_logger().debug(f"Node : {node_id} found")
             button = results.first(Button)
-            button.remove_class("node_enabled", "node_disabled")
-            button.add_class("node_enabled" if node.is_enabled else "node_disabled")
+            for state in NodeState:
+                button.remove_class(f"node-state-{state.name.lower()}")
+
+            # Add the current node-state class.
+            button.add_class(f"node-state-{node.state.name.lower()}")
+
+
+            button.styles.color = node.state.colour
+
+
             get_logger().debug(f"   - State : {button.classes}")
             button.disabled = not node.is_interactive
             get_logger().debug(f"   - Enabled : {button.disabled}")

--- a/src/runconf_ui/textual/widgets/enable_disable_panel.py
+++ b/src/runconf_ui/textual/widgets/enable_disable_panel.py
@@ -140,7 +140,6 @@ class EnableDisablePanel(Vertical):
 
             button.styles.color = node.state.colour
 
-
             get_logger().debug(f"   - State : {button.classes}")
             button.disabled = not node.is_interactive
             get_logger().debug(f"   - Enabled : {button.disabled}")

--- a/src/runconf_ui/textual/widgets/enable_disable_panel.py
+++ b/src/runconf_ui/textual/widgets/enable_disable_panel.py
@@ -2,7 +2,7 @@ from textual import on
 from textual.containers import ScrollableContainer, Vertical
 from textual.widgets import Button, Static
 
-from runconf_ui.state_tree import NodeStatus, NodeState
+from runconf_ui.state_tree import NodeState, NodeStatus
 from runconf_ui.utils import get_logger
 
 from ..messages import NodeToggledMessage

--- a/src/runconf_ui/utils/rich_utils.py
+++ b/src/runconf_ui/utils/rich_utils.py
@@ -11,15 +11,18 @@ Colour scheme:
 from confmodel_dal import component_disabled
 from rich.tree import Tree
 
-from runconf_ui.state_tree import Group, Node, State, compute_state
+from runconf_ui.state_tree import Group, Node, compute_state
 
 # Yeah sorry about this
+from runconf_ui.state_tree.node_state import NodeState
 from runconf_ui.system_configuration.config_reader import _natural_key
 
-_COLOURS: dict[State, str] = {
-    State.ENABLED: "green",
-    State.DISABLED: "red",
-    State.PARENT_DISABLED: "grey46",
+_COLOURS: dict[NodeState, str] = {
+    NodeState.ENABLED: "green",
+    NodeState.DISABLED: "red",
+    NodeState.PARTIALLY_ENABLED: "orange3",
+    NodeState.PARENT_DISABLED: "grey46",
+    NodeState.ERROR_STATE: "grey3"
 }
 
 
@@ -36,7 +39,7 @@ def sort_children(children: list[Node]) -> list[Node]:
     )
 
 
-def _format_label(label: str, state: State) -> str:
+def _format_label(label: str, state: NodeState) -> str:
     """Format a label with color and state annotation for Rich rendering.
 
     :param label: The label text to format
@@ -114,10 +117,10 @@ class ConfigTreeRenderer:
         :rtype: Tree
         """
         tree = Tree(f"[bold green]{self.session.id}")
-        self._render_config_branch(tree, self.session, State.ENABLED)
+        self._render_config_branch(tree, self.session, NodeState.ENABLED)
         return tree
 
-    def _calc_config_state(self, dal, parent_state: State) -> State:
+    def _calc_config_state(self, dal, parent_state: NodeState) -> NodeState:
         """Calculate the state of a DAL object based on parent and resource state.
 
         :param dal: The DAL object to calculate state for
@@ -125,18 +128,18 @@ class ConfigTreeRenderer:
         :returns: The calculated state for the DAL
         :rtype: State
         """
-        if parent_state is not State.ENABLED:
-            return State.PARENT_DISABLED
+        if parent_state is not NodeState.ENABLED:
+            return NodeState.PARENT_DISABLED
 
         if "Resource" not in self.config.superclasses(dal.className(), all=True):
             return parent_state
 
         if component_disabled(self.config._obj, self.session.id, dal.id):
-            return State.DISABLED
+            return NodeState.DISABLED
 
-        return State.ENABLED
+        return NodeState.ENABLED
 
-    def _render_config_branch(self, branch, dal, parent_state: State) -> None:
+    def _render_config_branch(self, branch, dal, parent_state: NodeState) -> None:
         """Recursively render configuration tree branches.
 
         :param branch: The Rich tree branch to render into

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -14,6 +14,7 @@ from runconf_ui.state_tree import (
     AdjustableAttribute,
     DisableAttribute,
     DisableComponent,
+    NodeState
 )
 
 # ---------------------------------------------------------------------------
@@ -58,7 +59,9 @@ class TestDisableComponent:
         adapter = DisableComponent(
             consolidated_config, consolidated_session, resource_dal
         )
-        assert adapter.get() is True
+        assert NodeState.state_to_bool(adapter.get())
+        assert adapter.get() == NodeState.ENABLED
+
 
     def test_set_false_disables(
         self, consolidated_config, consolidated_session, resource_dal
@@ -67,7 +70,8 @@ class TestDisableComponent:
             consolidated_config, consolidated_session, resource_dal
         )
         adapter.set(False)
-        assert adapter.get() is False
+        assert not NodeState.state_to_bool(adapter.get())
+        assert adapter.get() == NodeState.DISABLED
         assert component_disabled(
             consolidated_config._obj, consolidated_session.id, resource_dal.id
         )
@@ -82,7 +86,7 @@ class TestDisableComponent:
             consolidated_config, consolidated_session, resource_dal
         )
         adapter.set(True)
-        assert adapter.get() is True
+        assert adapter.get() == NodeState.ENABLED
         assert not component_disabled(
             consolidated_config._obj, consolidated_session.id, resource_dal.id
         )
@@ -116,9 +120,10 @@ class TestDisableAttribute:
 
     def test_get_reflects_attribute_value(self, adapter, resource_dal):
         resource_dal.tp_generation_enabled = True
-        assert adapter.get() is True
+        assert adapter.get() == NodeState.ENABLED
         resource_dal.tp_generation_enabled = False
-        assert adapter.get() is False
+        assert adapter.get() == NodeState.DISABLED
+
 
     def test_disabled_when_dal_resource_disabled(
         self, adapter, consolidated_config, consolidated_session, resource_dal
@@ -127,7 +132,7 @@ class TestDisableAttribute:
         disable_component(
             consolidated_config._obj, consolidated_session.id, resource_dal.id
         )
-        assert adapter.get() is False
+        assert adapter.get() == NodeState.DISABLED
 
     def test_set_updates_attribute(self, adapter, resource_dal):
         adapter.set(True)
@@ -147,7 +152,7 @@ class TestDisableAttribute:
             enabled_value=1001,
             disabled_value=1002,
         )
-        assert adapter.get() is True
+        assert adapter.get() == NodeState.ENABLED
         adapter.set(False)
         assert non_resource_dal.sid == 1002
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -14,7 +14,7 @@ from runconf_ui.state_tree import (
     AdjustableAttribute,
     DisableAttribute,
     DisableComponent,
-    NodeState
+    NodeState,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,11 +15,11 @@ from runconf_ui.state_tree import (
     DisableComponent,
     Group,
     Leaf,
-    State,
     build_index,
     disabled_child_nodes,
     labelled,
 )
+from runconf_ui.state_tree.node_state import NodeState
 from runconf_ui.system_configuration import SystemConfigReader
 
 
@@ -56,12 +56,6 @@ class TestTreeIntegration:
     def tpc_tree(
         self, consolidated_config, consolidated_session, ru01, ru02, ru_segment
     ):
-        """
-        TPC (all):
-          CRP4 (any): ru-01  (votes=True)
-          CRP5 (any): ru-02  (votes=True)
-          ru-segment          (votes=False, propagate=True)
-        """
         # Reset all DALs to enabled before (re)building the tree.
         for dal in (ru01, ru02, ru_segment):
             _leaf(consolidated_config, consolidated_session, dal).set(True)
@@ -72,10 +66,10 @@ class TestTreeIntegration:
             consolidated_config, consolidated_session, ru_segment, "ru-segment"
         )
 
-        root = Group("TPC", strategy=all)
+        root = Group("TPC")
         root.at("CRP4").add(ru01_leaf)
         root.at("CRP5").add(ru02_leaf)
-        root.add(seg_leaf, votes=False, propagate=True)
+        root.add(seg_leaf)
         return root
 
     @pytest.fixture(autouse=True)
@@ -84,15 +78,15 @@ class TestTreeIntegration:
         tpc_tree.set(True)
 
     def test_all_enabled_by_default(self, tpc_tree):
-        assert tpc_tree.get() is True
+        assert tpc_tree.get() == NodeState.ENABLED
 
-    def test_disabling_one_crp_disables_root(self, tpc_tree):
+    def test_partial_enabling(self, tpc_tree):
         tpc_tree.at("CRP4").set(False)
-        assert tpc_tree.get() is False
+        assert tpc_tree.get() == NodeState.PARTIALLY_ENABLED
 
     def test_controlled_object_propagates_with_root(self, tpc_tree):
         tpc_tree.set(False)
-        assert build_index(tpc_tree)["ru-segment"].get() is False
+        assert build_index(tpc_tree)["ru-segment"].get() == NodeState.DISABLED
 
     def test_disabled_children_diagnostic(self, tpc_tree):
         tpc_tree.at("CRP4").set(False)
@@ -102,8 +96,8 @@ class TestTreeIntegration:
     def test_parent_disabled_propagates_to_non_voting_child(self, tpc_tree):
         tpc_tree.at("CRP4").set(False)
         statuses = {s.node.label: s for s in labelled(tpc_tree) if s.node.label}
-        assert statuses["TPC"].state == State.DISABLED
-        assert statuses["ru-segment"].state == State.PARENT_DISABLED
+        assert statuses["TPC"].state == NodeState.PARTIALLY_ENABLED
+        assert statuses["ru-segment"].state == NodeState.ENABLED
 
     def test_build_index_contains_all_labelled(self, tpc_tree):
         assert set(build_index(tpc_tree).keys()) == {
@@ -164,9 +158,9 @@ class TestSystemConfigReaderIntegration:
             next(g for g in assembled.disableable if g.id == "Detector").systems[0].root
         )
         root.set(False)
-        assert root.get() is False
+        assert root.get() == NodeState.DISABLED
         root.set(True)
-        assert root.get() is True
+        assert root.get() == NodeState.ENABLED
 
     def test_non_existent_objects_produce_no_group(self, assembled):
         assert "NotReal" not in [g.id for g in assembled.disableable]
@@ -181,8 +175,8 @@ class TestDalSave:
     @pytest.fixture
     def backend(self, tmp_config_path, dummy_context):
         b = RunconfUIBackend(dummy_context)
-        b.set_daq_version(tmp_config_path.parent)
-        b.set_daq_session(tmp_config_path)
+        b.session_manager.set_daq_version(tmp_config_path.parent)
+        b.session_manager.set_daq_session(tmp_config_path)
         b.open_selected_session()
         return b
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -4,7 +4,7 @@ Unit tests for nodes.py.
 Uses simple stub adapters — no conffwk dependency.
 """
 
-from runconf_ui.state_tree import Group, Leaf
+from runconf_ui.state_tree import Group, Leaf, NodeState
 
 # ---------------------------------------------------------------------------
 # Stub adapter
@@ -12,7 +12,10 @@ from runconf_ui.state_tree import Group, Leaf
 
 
 class StubAdapter:
-    def __init__(self, value: bool = True):
+    def __init__(self, value: NodeState|bool = True):
+        if isinstance(value, bool):
+            value = NodeState.bool_to_state(value)
+        
         self._value = value
         self._dal_enabled = True
 
@@ -20,6 +23,8 @@ class StubAdapter:
         return self._value
 
     def set(self, value):
+        if not isinstance(value, NodeState):
+            value  = NodeState.bool_to_state(value)
         self._value = value
 
     def dal_enabled(self):
@@ -33,14 +38,12 @@ def leaf(value: bool = True, label: str = "") -> Leaf:
 # ---------------------------------------------------------------------------
 # Leaf
 # ---------------------------------------------------------------------------
-
-
 class TestLeaf:
     def test_get_and_set(self):
         n = leaf(True)
-        assert n.get() is True
+        assert n.get() == NodeState.ENABLED
         n.set(False)
-        assert n.get() is False
+        assert n.get() == NodeState.DISABLED
 
     def test_label(self):
         assert leaf(label="my-leaf").label == "my-leaf"
@@ -52,34 +55,24 @@ class TestLeaf:
 
 
 class TestGroupGet:
-    def test_all_strategy_true_when_all_enabled(self):
-        g = Group(strategy=all)
+    def test_group_true(self):
+        g = Group()
         g.add(leaf(True)).add(leaf(True))
-        assert g.get() is True
+        assert g.get() == NodeState.ENABLED
 
-    def test_all_strategy_false_when_any_disabled(self):
-        g = Group(strategy=all)
-        g.add(leaf(True)).add(leaf(False))
-        assert g.get() is False
-
-    def test_any_strategy_true_when_one_enabled(self):
-        g = Group(strategy=any)
-        g.add(leaf(False)).add(leaf(True))
-        assert g.get() is True
-
-    def test_any_strategy_false_when_all_disabled(self):
-        g = Group(strategy=any)
+    def test_disabled(self):
+        g = Group()
         g.add(leaf(False)).add(leaf(False))
-        assert g.get() is False
+        assert g.get() == NodeState.DISABLED
 
-    def test_non_voting_children_do_not_affect_get(self):
-        g = Group(strategy=all)
-        g.add(leaf(True), votes=True)
-        g.add(leaf(False), votes=False, propagate=False)
-        assert g.get() is True
+    def test_partial_enable(self):
+        g = Group()
+        g.add(leaf(False)).add(leaf(True))
+        assert g.get() == NodeState.PARTIALLY_ENABLED
 
-    def test_empty_group_vacuously_true(self):
-        assert Group(strategy=all).get() is True
+
+    def test_empty_group_vacuously_disabled(self):
+        assert Group().get() == NodeState.DISABLED
 
 
 # ---------------------------------------------------------------------------
@@ -91,53 +84,21 @@ class TestGroupSet:
     def test_set_propagates_to_voting_and_propagate_true_children(self):
         voting = leaf(True)
         controlled = leaf(True)
-        g = Group(strategy=all)
-        g.add(voting, votes=True, propagate=True)
-        g.add(controlled, votes=False, propagate=True)
+        g = Group()
+        g.add(voting)
+        g.add(controlled)
         g.set(False)
-        assert voting.get() is False
-        assert controlled.get() is False
-
-    def test_set_does_not_propagate_to_propagate_false_children(self):
-        voting = leaf(True)
-        adjustable = leaf(True)
-        g = Group(strategy=all)
-        g.add(voting, votes=True)
-        g.add(adjustable, votes=False, propagate=False)
-        g.set(False)
-        assert voting.get() is False
-        assert adjustable.get() is True
+        assert voting.get() == NodeState.DISABLED
+        assert controlled.get() == NodeState.DISABLED
 
     def test_set_propagates_through_nested_groups(self):
         inner_leaf = leaf(True)
-        inner = Group(strategy=all)
+        inner = Group()
         inner.add(inner_leaf)
-        outer = Group(strategy=all)
+        outer = Group()
         outer.add(inner)
         outer.set(False)
-        assert inner_leaf.get() is False
-
-
-# ---------------------------------------------------------------------------
-# Group — gated_get()
-# ---------------------------------------------------------------------------
-
-
-class TestGroupGatedGet:
-    def test_returns_false_when_parent_disabled(self):
-        child = leaf(True)
-        g = Group(strategy=all)
-        g.add(leaf(False))  # forces parent off
-        g.add(child)
-        assert g.get() is False
-        assert g.gated_get(child) is False
-
-    def test_returns_child_state_when_parent_enabled(self):
-        child = leaf(False)
-        g = Group(strategy=any)
-        g.add(leaf(True)).add(child)
-        assert g.get() is True
-        assert g.gated_get(child) is False
+        assert inner_leaf.get() == NodeState.DISABLED
 
 
 # ---------------------------------------------------------------------------
@@ -147,22 +108,22 @@ class TestGroupGatedGet:
 
 class TestGroupAt:
     def test_at_creates_and_reuses_subgroup(self):
-        root = Group("root", strategy=all)
+        root = Group("root", )
         sub1 = root.at("CRP4")
         sub2 = root.at("CRP4")
         assert isinstance(sub1, Group)
         assert sub1 is sub2
 
     def test_at_creates_nested_path(self):
-        root = Group("root", strategy=all)
+        root = Group("root", )
         deep = root.at("CRP4", "TPG")
         assert deep.label == "TPG"
         assert root.at("CRP4").at("TPG") is deep
 
     def test_at_subgroup_participates_in_parent_state(self):
-        root = Group("root", strategy=all)
+        root = Group("root", )
         root.at("CRP4").add(leaf(True))
-        assert root.get() is True
+        assert root.get() == NodeState.ENABLED
 
 
 # ---------------------------------------------------------------------------
@@ -174,14 +135,13 @@ class TestGroupStructure:
     def test_children_and_voting_children(self):
         g = Group()
         a, b = leaf(), leaf()
-        g.add(a, votes=True).add(b, votes=False)
+        g.add(a).add(b)
         assert g.children == [a, b]
-        assert g.voting_children == [a]
 
     def test_iter_yields_node_votes_propagate(self):
         g = Group()
         a, b, c = leaf(), leaf(), leaf()
-        g.add(a, votes=True, propagate=True)
-        g.add(b, votes=False, propagate=True)
-        g.add(c, votes=False, propagate=False)
-        assert list(g) == [(a, True, True), (b, False, True), (c, False, False)]
+        g.add(a)
+        g.add(b)
+        g.add(c)
+        assert list(g) == [a,b,c]

--- a/tests/test_runconfui_backend.py
+++ b/tests/test_runconfui_backend.py
@@ -8,13 +8,14 @@ get_values, save_config) against a real conffwk configuration.
 import pytest
 
 from runconf_ui import RunconfUIBackend
+from runconf_ui.state_tree import NodeState
 
 
 @pytest.fixture(scope="module")
 def backend(tmp_config_path, dummy_context):
     b = RunconfUIBackend(dummy_context)
-    b.set_daq_version(tmp_config_path.parent)
-    b.set_daq_session(tmp_config_path)
+    b.session_manager.set_daq_version(tmp_config_path.parent)
+    b.session_manager.set_daq_session(tmp_config_path)
     b.open_selected_session()
     return b
 
@@ -27,28 +28,31 @@ def backend(tmp_config_path, dummy_context):
 class TestDisableableBackend:
     def test_toggle_top_level_propagates_to_children(self, backend):
         backend.set_value("Detector", "Readout", True)
-        assert backend.get_value("Detector", "Readout")
-        assert backend.get_value("Detector", "Readout__ru-01")
-        assert backend.get_value("Detector", "Readout__ru-02")
+        assert backend.get_value("Detector", "Readout") == NodeState.ENABLED
+        assert backend.get_value("Detector", "Readout__ru-01") == NodeState.ENABLED
+        assert backend.get_value("Detector", "Readout__ru-02") == NodeState.ENABLED
 
         backend.toggle("Detector", "Readout")
-        assert not backend.get_value("Detector", "Readout")
-        assert not backend.get_value("Detector", "Readout__ru-01")
-        assert not backend.get_value("Detector", "Readout__ru-02")
+        assert backend.get_value("Detector", "Readout") == NodeState.DISABLED
+        assert backend.get_value("Detector", "Readout__ru-01") == NodeState.DISABLED
+        assert backend.get_value("Detector", "Readout__ru-02") == NodeState.DISABLED
 
-        backend.toggle("Detector", "Readout")  # restore
+        backend.set_value("Detector", "Readout", NodeState.ENABLED)  # restore
+        backend.set_value("Detector", "Readout__ru-01", NodeState.ENABLED)
+        backend.set_value("Detector", "Readout__ru-02", NodeState.ENABLED)
+
 
     def test_toggle_subsystem_updates_parent_state(self, backend):
         backend.set_value("Detector", "Readout", True)
 
         # Disabling one subsystem leaves parent enabled (OR semantics for subsystem_dependent)
         backend.toggle("Detector", "Readout__ru-02")
-        assert backend.get_value("Detector", "Readout")
-        assert not backend.get_value("Detector", "Readout__ru-02")
+        assert backend.get_value("Detector", "Readout") == NodeState.PARTIALLY_ENABLED
+        assert backend.get_value("Detector", "Readout__ru-02") == NodeState.DISABLED
 
         # Disabling both subsystems disables parent
         backend.toggle("Detector", "Readout__ru-01")
-        assert not backend.get_value("Detector", "Readout")
+        assert backend.get_value("Detector", "Readout") == NodeState.DISABLED
 
         backend.toggle("Detector", "Readout")  # restore
 
@@ -56,25 +60,27 @@ class TestDisableableBackend:
         backend.set_value("Detector", "Readout", True)
         vals = backend.get_values()
 
-        assert vals["Detector"]["Readout"].is_enabled
-        assert vals["Detector"]["Readout__ru-01"].is_enabled
-        assert vals["Detector"]["Readout__ru-02"].is_enabled
+        assert vals["Detector"]["Readout"].state == NodeState.ENABLED
+        assert vals["Detector"]["Readout__ru-01"].state == NodeState.ENABLED
+        assert vals["Detector"]["Readout__ru-02"].state == NodeState.ENABLED
 
         backend.toggle("Detector", "Readout__ru-02")
         vals = backend.get_values()
-        assert not vals["Detector"]["Readout__ru-02"].is_enabled
+        assert not vals["Detector"]["Readout__ru-02"].state == NodeState.ENABLED
         assert vals["Detector"][
             "Readout__ru-02"
         ].is_interactive  # still interactive (parent on)
 
-        backend.toggle("Detector", "Readout__ru-01")
+        backend.set_value("Detector", "Readout", NodeState.DISABLED)
+        # backend.set_value("Detector", "Readout__ru-01", NodeState.DISABLED)
+        # backend.set_value("Detector", "Readout__ru-02", NodeState.DISABLED)
         vals = backend.get_values()
-        # Both subsystems off → parent off → children become non-interactive
-        assert not vals["Detector"]["Readout"].is_enabled
+
+        assert backend.get_value("Detector", "Readout") == NodeState.DISABLED
+        
+        # Both subsystems off → parent off → children become non-intractive
         assert not vals["Detector"]["Readout__ru-01"].is_interactive
         assert not vals["Detector"]["Readout__ru-02"].is_interactive
-
-        backend.toggle("Detector", "Readout")  # restore
 
 
 # ---------------------------------------------------------------------------
@@ -85,10 +91,10 @@ class TestDisableableBackend:
 class TestRelationshipBackend:
     def test_toggle_relationship(self, backend):
         backend.set_value("Trigger", "RandomTrigger", True)
-        assert backend.get_value("Trigger", "RandomTrigger")
+        assert backend.get_value("Trigger", "RandomTrigger") == NodeState.ENABLED
 
         backend.set_value("Trigger", "RandomTrigger", False)
-        assert not backend.get_value("Trigger", "RandomTrigger")
+        assert backend.get_value("Trigger", "RandomTrigger") == NodeState.DISABLED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_textual.py
+++ b/tests/test_textual.py
@@ -11,7 +11,9 @@ from rich.tree import Tree
 from textual.widgets import Button, Select, Static, TabbedContent
 
 from runconf_ui import RunconfContext, RunconfUIBackend
-from runconf_ui.state_tree import Group, Leaf, NodeStatus, State
+from runconf_ui.backend.runconf_ui_backend import SessionManager
+from runconf_ui.state_tree import Group, Leaf, NodeStatus
+from runconf_ui.state_tree.node_state import NodeState
 from runconf_ui.textual.runconf_ui_app import RunconfUIApp
 from runconf_ui.textual.screens import (
     CreateScreen,
@@ -54,13 +56,30 @@ class _StubAdapter:
 
 
 def _node(label: str, enabled=True, parent=None):
-    state = State.ENABLED if enabled else State.DISABLED
-    return NodeStatus(
+    state = NodeState.ENABLED if enabled else NodeState.DISABLED
+    return NodeStatus( 
         node=Leaf(_StubAdapter(enabled), label=label),  # type: ignore
         state=state,
         parent=parent,
     )
 
+def _make_session_manager(
+    versions=None,
+    sessions=None,
+):
+    s = MagicMock(SessionManager)
+    s.get_current_version.return_value = (versions or [Path("/fake/v1")])[0]
+    s.get_daq_versions.return_value = versions or [
+        Path("/fake/v1"),
+        Path("/fake/v2"),
+    ]
+    
+    s.get_sessions.return_value = sessions or [
+        Path("/fake/v1/session-a.data.xml"),
+        Path("/fake/v1/session-b.data.xml"),
+    ]
+    
+    return s 
 
 def _make_backend(
     versions=None,
@@ -71,17 +90,7 @@ def _make_backend(
 ):
     b = MagicMock(spec=RunconfUIBackend)
 
-    b.get_daq_versions.return_value = versions or [
-        Path("/fake/v1"),
-        Path("/fake/v2"),
-    ]
-
-    b.get_current_version.return_value = (versions or [Path("/fake/v1")])[0]
-
-    b.get_sessions.return_value = sessions or [
-        Path("/fake/v1/session-a.data.xml"),
-        Path("/fake/v1/session-b.data.xml"),
-    ]
+    b.session_manager = _make_session_manager(versions)
 
     b.get_disableable_values.return_value = disableable or {}
     b.get_adjustable_values.return_value = adjustable or {}
@@ -99,11 +108,11 @@ def _make_backend(
 
 
 def _loaded_backend():
-    parent = Group("Readout", strategy=all)
+    parent = Group("Readout")
 
     dis = {
         "Detector": {
-            "Readout": NodeStatus(node=parent, state=State.ENABLED, parent=None),
+            "Readout": NodeStatus(node=parent, state=NodeState.ENABLED, parent=None),
             "Readout__ru-01": _node("ru-01", True, parent),
             "Readout__ru-02": _node("ru-02", True, parent),
         }
@@ -392,8 +401,7 @@ async def test_buttons_render_after_load(loaded_pilot):
 @pytest.mark.slow
 async def test_enabled_node_has_class(loaded_pilot):
     button = loaded_pilot.app.query_one("#Readout", Button)
-
-    assert "node_enabled" in button.classes
+    assert "node-state-enabled" in button.classes
 
 
 @pytest.mark.slow

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -60,15 +60,6 @@ class TestComputeState:
     def test_disabled_node_no_parent(self):
         assert compute_state(leaf(NodeState.DISABLED), None) == NodeState.DISABLED
 
-    def test_enabled_node_with_disabled_parent_returns_parent_disabled(self):
-        top_level = Group(label="Top Group")
-        top_level.add(leaf(False, label="Top Leaf"))
-        
-        child = leaf(True, label="Sub Leaf")
-        top_level.at("subgroup").add(child)
-                
-        print(top_level.get())
-        assert compute_state(top_level.at("subgroup"), top_level) == NodeState.PARENT_DISABLED
 
     def test_disabled_node_with_disabled_parent_returns_parent_disabled(self):
         # Parent gating takes precedence — node's own DISABLED is not visible
@@ -99,7 +90,7 @@ class TestComputeState:
 
     def test_group_node_parent_disabled(self):
         child_group = Group()
-        child_group.add(leaf(True))
+        child_group.add(leaf(False))
         parent = Group()
         parent.add(leaf(False)).add(child_group)
         assert compute_state(child_group, parent) == NodeState.PARENT_DISABLED
@@ -122,11 +113,23 @@ class TestNodeStatus:
         )
 
     def test_not_interactive_when_parent_disabled(self):
+        parent = Group()
+        child = leaf(False)
+        parent.add(child)
+        parent.at("subgroup").add(leaf(False))
+
         assert (
             NodeStatus(
-                node=leaf(True), state=NodeState.ENABLED, parent=Group().add(leaf(False))
+                node=child, state=NodeState.DISABLED, parent=parent
             ).is_interactive
             is False
+        )
+        
+        assert (
+            NodeStatus(
+                node=parent, state=NodeState.DISABLED, parent=None
+            ).is_interactive
+            is True
         )
         
 # ---------------------------------------------------------------------------

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -11,13 +11,13 @@ from runconf_ui.state_tree import (
     Group,
     Leaf,
     NodeStatus,
-    State,
     build_index,
     compute_state,
     disabled_child_nodes,
     labelled,
     walk,
 )
+from runconf_ui.state_tree.node_state import NodeState
 
 # ---------------------------------------------------------------------------
 # Stub adapter
@@ -25,7 +25,10 @@ from runconf_ui.state_tree import (
 
 
 class StubAdapter:
-    def __init__(self, value: bool = True, dal_enabled: bool = True):
+    def __init__(self, value: NodeState|bool = True, dal_enabled: bool = True):
+        if isinstance(value, bool):
+            value = NodeState.bool_to_state(value)
+        
         self._value = value
         self._dal_enabled = dal_enabled
 
@@ -33,14 +36,16 @@ class StubAdapter:
         return self._value
 
     def set(self, value):
+        if not isinstance(value, NodeState):
+            value  = NodeState.bool_to_state(value)
         self._value = value
 
     def dal_enabled(self):
         return self._dal_enabled
 
 
-def leaf(value: bool = True, label: str = "", dal_enabled: bool = True) -> Leaf:
-    return Leaf(StubAdapter(value, dal_enabled=dal_enabled), label=label)  # type: ignore
+def leaf(value: bool = True, label: str = "", dal_enabled: bool=True) -> Leaf:
+    return Leaf(StubAdapter(value, dal_enabled), label=label)  # type: ignore
 
 
 # ---------------------------------------------------------------------------
@@ -50,46 +55,54 @@ def leaf(value: bool = True, label: str = "", dal_enabled: bool = True) -> Leaf:
 
 class TestComputeState:
     def test_enabled_node_no_parent(self):
-        assert compute_state(leaf(True), None) == State.ENABLED
+        assert compute_state(leaf(NodeState.ENABLED), None) == NodeState.ENABLED
 
     def test_disabled_node_no_parent(self):
-        assert compute_state(leaf(False), None) == State.DISABLED
+        assert compute_state(leaf(NodeState.DISABLED), None) == NodeState.DISABLED
 
     def test_enabled_node_with_disabled_parent_returns_parent_disabled(self):
-        child = leaf(True)
-        parent = Group(strategy=all)
-        parent.add(leaf(False)).add(child)
-        assert compute_state(child, parent) == State.PARENT_DISABLED
+        top_level = Group(label="Top Group")
+        top_level.add(leaf(False, label="Top Leaf"))
+        
+        l = leaf(True, label="Sub Leaf")
+        top_level.at("subgroup").add(l)
+                
+        print(top_level.get())
+        assert compute_state(top_level.at("subgroup"), top_level) == NodeState.PARENT_DISABLED
 
     def test_disabled_node_with_disabled_parent_returns_parent_disabled(self):
         # Parent gating takes precedence — node's own DISABLED is not visible
         # when the parent is already off.
         child = leaf(False)
-        parent = Group(strategy=all)
+        parent = Group()
         parent.add(leaf(False)).add(child)
-        assert compute_state(child, parent) == State.PARENT_DISABLED
+        assert compute_state(child, parent) == NodeState.PARENT_DISABLED
 
     def test_dal_resource_disabled_returns_parent_disabled(self):
+        g = Group()
+        l = leaf(True, dal_enabled=False)
+        g.add(l)
+        
         assert (
-            compute_state(leaf(True, dal_enabled=False), None) == State.PARENT_DISABLED
+            compute_state(l, g) == NodeState.PARENT_DISABLED
         )
 
     def test_group_node_enabled(self):
-        g = Group(strategy=all)
-        g.add(leaf(True))
-        assert compute_state(g, None) == State.ENABLED
+        g = Group()
+        g.add(leaf(NodeState.ENABLED))
+        assert compute_state(g, None) == NodeState.ENABLED
 
     def test_group_node_disabled(self):
-        g = Group(strategy=all)
+        g = Group()
         g.add(leaf(False))
-        assert compute_state(g, None) == State.DISABLED
+        assert compute_state(g, None) == NodeState.DISABLED
 
     def test_group_node_parent_disabled(self):
-        child_group = Group(strategy=all)
+        child_group = Group()
         child_group.add(leaf(True))
-        parent = Group(strategy=all)
+        parent = Group()
         parent.add(leaf(False)).add(child_group)
-        assert compute_state(child_group, parent) == State.PARENT_DISABLED
+        assert compute_state(child_group, parent) == NodeState.PARENT_DISABLED
 
 
 # ---------------------------------------------------------------------------
@@ -100,23 +113,22 @@ class TestComputeState:
 class TestNodeStatus:
     def test_is_interactive_for_enabled_and_disabled(self):
         assert (
-            NodeStatus(node=leaf(), state=State.ENABLED, parent=None).is_interactive
+            NodeStatus(node=leaf(), state=NodeState.ENABLED, parent=None).is_interactive
             is True
         )
         assert (
-            NodeStatus(node=leaf(), state=State.DISABLED, parent=None).is_interactive
+            NodeStatus(node=leaf(), state=NodeState.DISABLED, parent=None).is_interactive
             is True
         )
 
     def test_not_interactive_when_parent_disabled(self):
         assert (
             NodeStatus(
-                node=leaf(), state=State.PARENT_DISABLED, parent=None
+                node=leaf(True), state=NodeState.ENABLED, parent=Group().add(leaf(False))
             ).is_interactive
             is False
         )
-
-
+        
 # ---------------------------------------------------------------------------
 # walk()
 # ---------------------------------------------------------------------------
@@ -124,9 +136,9 @@ class TestNodeStatus:
 
 class TestWalk:
     def test_yields_root_first_then_depth_first(self):
-        root = Group("root", strategy=all)
+        root = Group("root")
         c1 = leaf(label="c1")
-        sub = Group("sub", strategy=all)
+        sub = Group("sub")
         gc = leaf(label="gc")
         c2 = leaf(label="c2")
         sub.add(gc)
@@ -134,7 +146,7 @@ class TestWalk:
         assert [s.node for s in walk(root)] == [root, c1, sub, gc, c2]
 
     def test_sets_correct_parent(self):
-        root = Group("root", strategy=all)
+        root = Group("root")
         child = leaf(label="child")
         root.add(child)
         statuses = {s.node: s for s in walk(root)}
@@ -142,10 +154,10 @@ class TestWalk:
         assert statuses[root].parent is None
 
     def test_all_nodes_receive_state(self):
-        root = Group("root", strategy=all)
+        root = Group("root")
         root.add(leaf(True, label="a")).add(leaf(False, label="b"))
         for status in walk(root):
-            assert isinstance(status.state, State)
+            assert isinstance(status.state, NodeState)
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +167,7 @@ class TestWalk:
 
 class TestLabelled:
     def test_anonymous_nodes_excluded(self):
-        root = Group("root", strategy=all)
+        root = Group("root")
         root.add(leaf(label=""))
         root.add(leaf(label="x"))
         labels = [s.node.label for s in labelled(root)]
@@ -163,7 +175,7 @@ class TestLabelled:
         assert "x" in labels
 
     def test_unlabelled_root_excluded(self):
-        root = Group(label="", strategy=all)
+        root = Group(label="")
         root.add(leaf(label="child"))
         assert root not in [s.node for s in labelled(root)]
 
@@ -177,18 +189,12 @@ class TestDisabledChildNodes:
     def test_returns_voting_children_that_are_off(self):
         on = leaf(True, label="on")
         off = leaf(False, label="off")
-        g = Group(strategy=all)
+        g = Group()
         g.add(on).add(off)
         assert disabled_child_nodes(g) == [off]
 
-    def test_ignores_non_voting_children(self):
-        g = Group(strategy=all)
-        g.add(leaf(True), votes=True)
-        g.add(leaf(False), votes=False)
-        assert disabled_child_nodes(g) == []
-
     def test_empty_when_all_enabled(self):
-        g = Group(strategy=all)
+        g = Group()
         g.add(leaf(True)).add(leaf(True))
         assert disabled_child_nodes(g) == []
 
@@ -200,8 +206,8 @@ class TestDisabledChildNodes:
 
 class TestBuildIndex:
     def test_flat_and_nested_nodes_indexed(self):
-        root = Group("root", strategy=all)
-        sub = Group("sub", strategy=any)
+        root = Group("root")
+        sub = Group("sub")
         deep = leaf(label="deep")
         a = leaf(label="a")
         sub.add(deep)
@@ -210,17 +216,17 @@ class TestBuildIndex:
         assert set(index.keys()) == {"root", "a", "sub", "deep"}
 
     def test_raises_on_duplicate_labels(self):
-        root = Group("root", strategy=all)
+        root = Group("root")
         root.add(leaf(label="dup")).add(leaf(label="dup"))
         with pytest.raises(ValueError, match="dup"):
             build_index(root)
 
     def test_anonymous_nodes_excluded(self):
-        root = Group("root", strategy=all)
+        root = Group("root")
         root.add(leaf(label=""))
         assert "" not in build_index(root)
 
     def test_rebuild_is_idempotent(self):
-        root = Group("root", strategy=all)
+        root = Group("root")
         root.add(leaf(label="a"))
         assert build_index(root) == build_index(root)

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -64,8 +64,8 @@ class TestComputeState:
         top_level = Group(label="Top Group")
         top_level.add(leaf(False, label="Top Leaf"))
         
-        l = leaf(True, label="Sub Leaf")
-        top_level.at("subgroup").add(l)
+        child = leaf(True, label="Sub Leaf")
+        top_level.at("subgroup").add(child)
                 
         print(top_level.get())
         assert compute_state(top_level.at("subgroup"), top_level) == NodeState.PARENT_DISABLED
@@ -80,11 +80,11 @@ class TestComputeState:
 
     def test_dal_resource_disabled_returns_parent_disabled(self):
         g = Group()
-        l = leaf(True, dal_enabled=False)
-        g.add(l)
+        lf = leaf(True, dal_enabled=False)
+        g.add(lf)
         
         assert (
-            compute_state(l, g) == NodeState.PARENT_DISABLED
+            compute_state(lf, g) == NodeState.PARENT_DISABLED
         )
 
     def test_group_node_enabled(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 from rich.tree import Tree
 
 from runconf_ui.exceptions import ConfigReadException
-from runconf_ui.state_tree import State
+from runconf_ui.state_tree.node_state import NodeState
 from runconf_ui.utils.config_utils import (
     check_config_has_session,
     dal_in_config,
@@ -131,15 +131,15 @@ class TestConfigTreeRendererIntegration:
         assert renderer.session.id in tree.label
 
     def test_calc_config_state_real_objects(self, renderer, ru01):
-        state = renderer._calc_config_state(ru01, State.ENABLED)
+        state = renderer._calc_config_state(ru01, NodeState.ENABLED)
         # Should be ENABLED initially if component not disabled
-        assert state in (State.ENABLED, State.DISABLED, State.PARENT_DISABLED)
+        assert state in (NodeState.ENABLED, NodeState.DISABLED, NodeState.PARENT_DISABLED)
 
     def test_render_config_branch_recurses(self, renderer, ru_segment):
         # Use real DALs
         tree = Tree(f"[bold green]{renderer.session.id}")
         # _render_config_branch should not error
-        renderer._render_config_branch(tree, ru_segment, State.ENABLED)
+        renderer._render_config_branch(tree, ru_segment, NodeState.ENABLED)
         # At least one child node should be added
         assert len(tree.children) > 0
 
@@ -166,5 +166,5 @@ class TestConfigTreeRendererIntegration:
             lambda obj, session_id, dal_id: dal_id == "ru-01",
         )
 
-        state = renderer._calc_config_state(ru01, State.ENABLED)
-        assert state == State.DISABLED
+        state = renderer._calc_config_state(ru01, NodeState.ENABLED)
+        assert state == NodeState.DISABLED


### PR DESCRIPTION
# Description
**REQUIRES https://github.com/DUNE-DAQ/appmodel/pull/290**

- Add the ability to show objects as being partially enabled
- Remove logic for disabling "hidden" objects


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
